### PR TITLE
Adds support for transactions

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -33,7 +33,7 @@ func main() {
 		config.DB.Port,
 		config.DB.Name,
 	)
-	sqlstore, err := sqlstoreimpl.New(ctx, databaseURL)
+	sqlstore, err := sqlstoreimpl.New(ctx, databaseURL, true)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/system/impl/sqlstore_test.go
+++ b/internal/system/impl/sqlstore_test.go
@@ -17,7 +17,7 @@ func TestSystemSQLStoreService(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := context.Background()
-	store, err := impl.New(ctx, url)
+	store, err := impl.New(ctx, url, true)
 	require.NoError(t, err)
 
 	// populate the system_tables with a table

--- a/internal/tableland/impl/mesa_test.go
+++ b/internal/tableland/impl/mesa_test.go
@@ -1,0 +1,241 @@
+package impl
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/textileio/go-tableland/internal/tableland"
+	sqlstoreimpl "github.com/textileio/go-tableland/pkg/sqlstore/impl"
+	"github.com/textileio/go-tableland/pkg/tableregistry"
+	"github.com/textileio/go-tableland/pkg/tableregistry/impl/ethereum"
+	"github.com/textileio/go-tableland/tests"
+)
+
+func TestCreateTable(t *testing.T) {
+	ctx := context.Background()
+	tableregistry, tableID, controller := ethSetup(t)
+
+	url, err := tests.PostgresURL()
+	require.NoError(t, err)
+
+	sqlstore, err := sqlstoreimpl.New(ctx, url, true)
+	require.NoError(t, err)
+
+	mesa := NewTablelandMesa(sqlstore, tableregistry)
+
+	_, err = sqlstore.GetTable(ctx, tableID)
+	require.Error(t, err) // table does not exist on registry
+
+	_, err = sqlstore.Read(ctx, "SELECT * FROM test;")
+	require.Error(t, err) // table does not exist on user space
+
+	_, err = mesa.CreateTable(ctx, tableland.Request{
+		TableID:    tableID.String(),
+		Controller: controller,
+		Statement:  `CREATE TABLE "test" (a int);`,
+	})
+	require.NoError(t, err)
+
+	table, err := sqlstore.GetTable(ctx, tableID)
+	require.NoError(t, err) // table exists on registry
+	require.Equal(t, table.UUID, tableID)
+
+	data, err := sqlstore.Read(ctx, "SELECT * FROM test;")
+	require.Empty(t, data.(map[string]interface{})["rows"])
+	require.NoError(t, err) // table exists on user space
+}
+func TestCreateTableRollback(t *testing.T) {
+	ctx := context.Background()
+	tableregistry, tableID, _ := ethSetup(t) // ignore controller
+
+	url, err := tests.PostgresURL()
+	require.NoError(t, err)
+
+	sqlstore, err := sqlstoreimpl.New(ctx, url, true)
+	require.NoError(t, err)
+
+	mesa := NewTablelandMesa(sqlstore, tableregistry)
+
+	_, err = sqlstore.GetTable(ctx, tableID)
+	require.Error(t, err) // table does not exist on registry
+
+	_, err = sqlstore.Read(ctx, "SELECT * FROM test;")
+	require.Error(t, err) // table does not exist on user space
+
+	// use a controller bigger than 42 chars. this means that the CREATE TABLE will work but the INSERT INTO will not
+	_, err = mesa.CreateTable(ctx, tableland.Request{
+		TableID:    tableID.String(),
+		Controller: "0xE3c13de334225F3a922589918149B751524d2Ef87", // bigger than 42, to force an error
+		Statement:  `CREATE TABLE "test" (a int)`,
+	})
+	require.Error(t, err)
+
+	_, err = sqlstore.GetTable(ctx, tableID)
+	require.Error(t, err) // table does not exist on registry
+
+	_, err = sqlstore.Read(ctx, "SELECT * FROM test;")
+	require.Error(t, err) // table does not exist on registry
+}
+
+func TestCreateTableWithoutTransaction(t *testing.T) {
+	ctx := context.Background()
+	tableregistry, tableID, _ := ethSetup(t) // ignore controller
+
+	url, err := tests.PostgresURL()
+	require.NoError(t, err)
+
+	sqlstore, err := sqlstoreimpl.New(ctx, url, false)
+	require.NoError(t, err)
+
+	mesa := NewTablelandMesa(sqlstore, tableregistry)
+
+	_, err = sqlstore.GetTable(ctx, tableID)
+	require.Error(t, err) // table does not exist on registry
+
+	_, err = sqlstore.Read(ctx, "SELECT * FROM test;")
+	require.Error(t, err) // table does not exist on user space
+
+	// use a controller bigger than 42 chars. this means that the CREATE TABLE will work but the INSERT INTO will not
+	_, err = mesa.CreateTable(ctx, tableland.Request{
+		TableID:    tableID.String(),
+		Controller: "0xE3c13de334225F3a922589918149B751524d2Ef87", // bigger than 42, to force an error
+		Statement:  `CREATE TABLE "test" (a int)`,
+	})
+	require.Error(t, err)
+
+	// the transaction was disabled. the rollback does not work and we have an incosistency state across tables
+	_, err = sqlstore.GetTable(ctx, tableID)
+	require.Error(t, err) // table does not exist on registry
+
+	_, err = sqlstore.Read(ctx, "SELECT * FROM test;")
+	require.NoError(t, err) // table does exist on registry
+}
+
+// TODO: create a utility methods for this inside the tests package.
+func ethSetup(t *testing.T) (tableregistry.TableRegistry, uuid.UUID, string) {
+	key, auth := requireNewAuth(t)
+
+	alloc := make(core.GenesisAlloc)
+	alloc[auth.From] = core.GenesisAccount{Balance: big.NewInt(math.MaxInt64)}
+	backend := backends.NewSimulatedBackend(alloc, math.MaxInt64)
+
+	requireAuthGas(t, backend, auth)
+
+	//Deploy contract
+	address, _, contract, err := ethereum.DeployContract(
+		auth,
+		backend,
+	)
+
+	// commit all pending transactions
+	backend.Commit()
+	require.NoError(t, err)
+
+	if len(address.Bytes()) == 0 {
+		t.Error("Expected a valid deployment address. Received empty address byte array instead")
+	}
+
+	registry, err := ethereum.NewClient(backend, address)
+	require.NoError(t, err)
+
+	_, toAuth := requireNewAuth(t)
+	requireAuthGas(t, backend, toAuth)
+
+	tableID := uuid.New()
+	var n big.Int
+	n.SetString(strings.Replace(tableID.String(), "-", "", 4), 16)
+
+	requireTxn(t, backend, key, auth.From, toAuth.From, big.NewInt(1000000000000000000))
+	requireMint(t, backend, contract, toAuth, toAuth.From, &n)
+
+	return registry, tableID, toAuth.From.String()
+}
+
+func requireMint(
+	t *testing.T,
+	backend *backends.SimulatedBackend,
+	contract *ethereum.Contract,
+	txOpts *bind.TransactOpts,
+	to common.Address,
+	tableID *big.Int,
+) *big.Int {
+	tokenID := big.NewInt(0)
+
+	txn, err := contract.Mint(txOpts, to, tokenID, tableID, nil)
+	require.NoError(t, err)
+
+	backend.Commit()
+
+	receipt, err := backend.TransactionReceipt(context.Background(), txn.Hash())
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+
+	return tokenID
+}
+
+func requireTxn(
+	t *testing.T,
+	backend *backends.SimulatedBackend,
+	key *ecdsa.PrivateKey,
+	from common.Address,
+	to common.Address,
+	amt *big.Int,
+) {
+	nonce, err := backend.PendingNonceAt(context.Background(), from)
+	require.NoError(t, err)
+
+	gasLimit := uint64(21000)
+	gasPrice, err := backend.SuggestGasPrice(context.Background())
+	require.NoError(t, err)
+
+	var data []byte
+	txnData := &types.LegacyTx{
+		Nonce:    nonce,
+		GasPrice: gasPrice,
+		Gas:      gasLimit,
+		To:       &to,
+		Data:     data,
+		Value:    amt,
+	}
+	tx := types.NewTx(txnData)
+	signedTx, err := types.SignTx(tx, types.HomesteadSigner{}, key)
+	require.NoError(t, err)
+
+	bal, err := backend.BalanceAt(context.Background(), from, nil)
+	require.NoError(t, err)
+	require.NotZero(t, bal)
+
+	err = backend.SendTransaction(context.Background(), signedTx)
+	require.NoError(t, err)
+
+	backend.Commit()
+
+	receipt, err := backend.TransactionReceipt(context.Background(), signedTx.Hash())
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+}
+
+func requireAuthGas(t *testing.T, backend *backends.SimulatedBackend, auth *bind.TransactOpts) {
+	gas, err := backend.SuggestGasPrice(context.Background())
+	require.NoError(t, err)
+	auth.GasPrice = gas
+}
+
+func requireNewAuth(t *testing.T) (*ecdsa.PrivateKey, *bind.TransactOpts) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	auth := bind.NewKeyedTransactor(key) //nolint
+	return key, auth
+}

--- a/pkg/sqlstore/impl/pgx_store.go
+++ b/pkg/sqlstore/impl/pgx_store.go
@@ -6,33 +6,56 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/textileio/go-tableland/pkg/sqlstore"
 	"github.com/textileio/go-tableland/pkg/sqlstore/impl/system"
+	"github.com/textileio/go-tableland/pkg/sqlstore/impl/transactor"
 	"github.com/textileio/go-tableland/pkg/sqlstore/impl/user"
 )
 
 // SQLStorePGX implements the SQLStore interface using pgx.
 type SQLStorePGX struct {
-	pool *pgxpool.Pool
+	t *transactor.Transactor
 	*user.UserStore
 	*system.SystemStore
 }
 
-// Close closes the connection pool.
-func (db *SQLStorePGX) Close() {
-	db.pool.Close()
-}
-
-// New creates a new pgx pool and instantiate both the user and system stores.
-func New(ctx context.Context, postgresURI string) (sqlstore.SQLStore, error) {
+// New creates a new SQL store with transaction support and instantiate both the user and system stores.
+func New(ctx context.Context, postgresURI string, enableTx bool) (sqlstore.SQLStore, error) {
 	pool, err := pgxpool.Connect(ctx, postgresURI)
 	if err != nil {
 		return nil, err
 	}
 
-	userStore := user.New(pool)
-	systemStore, err := system.New(pool)
+	var t *transactor.Transactor
+	if enableTx {
+		t = transactor.New(pool)
+	} else {
+		t = transactor.NewWithoutTransaction(pool)
+	}
+
+	userStore := user.New(t)
+	systemStore, err := system.New(t)
 	if err != nil {
 		return nil, err
 	}
 
-	return &SQLStorePGX{pool, userStore, systemStore}, nil
+	return &SQLStorePGX{t, userStore, systemStore}, nil
+}
+
+// Begin initiates a new transaction.
+func (s *SQLStorePGX) Begin(ctx context.Context) error {
+	return s.t.Begin(ctx)
+}
+
+// Commit commits the current ongoing transaction.
+func (s *SQLStorePGX) Commit(ctx context.Context) error {
+	return s.t.Commit(ctx)
+}
+
+// Rollback rollbacks the current ongoing transaction.
+func (s *SQLStorePGX) Rollback(ctx context.Context) error {
+	return s.t.Rollback(ctx)
+}
+
+// Close closes the connection pool.
+func (s *SQLStorePGX) Close() {
+	s.t.Close()
 }

--- a/pkg/sqlstore/impl/pgx_store_test.go
+++ b/pkg/sqlstore/impl/pgx_store_test.go
@@ -1,0 +1,57 @@
+package impl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/textileio/go-tableland/tests"
+)
+
+func TestRollback(t *testing.T) {
+	url, err := tests.PostgresURL()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	store, err := New(ctx, url, true)
+	require.NoError(t, err)
+
+	err = store.Begin(ctx) // begin transaction
+	require.NoError(t, err)
+
+	err = store.Write(ctx, "CREATE TABLE valid (a int);")
+	require.NoError(t, err)
+
+	_, err = store.Read(ctx, "SELECT * FROM valid") // SELECT inside a transaction before rollback (table exist)
+	require.NoError(t, err)
+
+	err = store.Rollback(ctx)
+	require.NoError(t, err)
+
+	_, err = store.Read(ctx, "SELECT * FROM valid") // Same select as above after rollback (table does not exist)
+	require.Error(t, err)
+}
+
+func TestRollbackWithoutTransaction(t *testing.T) {
+	url, err := tests.PostgresURL()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	store, err := New(ctx, url, false)
+	require.NoError(t, err)
+
+	err = store.Begin(ctx) // begin transaction
+	require.NoError(t, err)
+
+	err = store.Write(ctx, "CREATE TABLE valid (a int);")
+	require.NoError(t, err)
+
+	_, err = store.Read(ctx, "SELECT * FROM valid") // SELECT inside a transaction before rollback (table exist)
+	require.NoError(t, err)
+
+	err = store.Rollback(ctx)
+	require.NoError(t, err)
+
+	_, err = store.Read(ctx, "SELECT * FROM valid") // Same select as above after rollback (table does exist)
+	require.NoError(t, err)
+}

--- a/pkg/sqlstore/impl/system/store_test.go
+++ b/pkg/sqlstore/impl/system/store_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stretchr/testify/require"
+	"github.com/textileio/go-tableland/pkg/sqlstore/impl/transactor"
 	"github.com/textileio/go-tableland/tests"
 )
 
@@ -19,7 +20,7 @@ func TestSystemStore(t *testing.T) {
 	pool, err := pgxpool.Connect(ctx, url)
 	require.NoError(t, err)
 
-	store, err := New(pool)
+	store, err := New(transactor.New(pool))
 	require.NoError(t, err)
 
 	_, err = store.GetTable(ctx, uuid.New())

--- a/pkg/sqlstore/impl/transactor/pgx_transactor.go
+++ b/pkg/sqlstore/impl/transactor/pgx_transactor.go
@@ -1,0 +1,112 @@
+package transactor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+// Transactor is how you have access to the database pool or the current database transaction.
+type Transactor struct {
+	pool    *pgxpool.Pool
+	tx      *pgx.Tx // current ongoing transaction
+	enabled bool
+}
+
+// New creates a new Transactor with transaction enabled.
+func New(pool *pgxpool.Pool) *Transactor {
+	return &Transactor{pool: pool, enabled: true}
+}
+
+// NewWithoutTransaction creates a new Transactor with transaction disabled.
+func NewWithoutTransaction(pool *pgxpool.Pool) *Transactor {
+	return &Transactor{pool: pool, enabled: false}
+}
+
+// Begin initiates a new transaction.
+func (s *Transactor) Begin(ctx context.Context) error {
+	if !s.enabled {
+		return nil
+	}
+
+	if s.tx != nil {
+		return errors.New("there is an ongoing transaction")
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %s", err)
+	}
+	s.tx = &tx
+	return nil
+}
+
+// Commit commits the current ongoing transaction.
+func (s *Transactor) Commit(ctx context.Context) error {
+	if !s.enabled {
+		return nil
+	}
+
+	if s.tx == nil {
+		return errors.New("there is no ongoing transaction")
+	}
+
+	err := (*s.tx).Commit(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to commit transaction: %s", err)
+	}
+	s.tx = nil
+	return nil
+}
+
+// Rollback rollbacks the current ongoing transaction.
+func (s *Transactor) Rollback(ctx context.Context) error {
+	if !s.enabled {
+		return nil
+	}
+
+	if s.tx == nil {
+		return errors.New("there is no ongoing transaction")
+	}
+
+	err := (*s.tx).Rollback(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to rollback transaction: %s", err)
+	}
+	s.tx = nil
+	return nil
+}
+
+// Close closes all connections in the pool.
+func (s *Transactor) Close() {
+	s.pool.Close()
+}
+
+// ConnString gets the connections string.
+func (s *Transactor) ConnString() string {
+	return s.pool.Config().ConnString()
+}
+
+// DBTX gets the db connection. It can be inside a transaction or not.
+func (s *Transactor) DBTX() DBTX {
+	if !s.enabled {
+		return s.pool
+	}
+
+	if s.tx == nil {
+		return s.pool
+	}
+
+	return (*s.tx)
+}
+
+// DBTX represents the API for interacting with the database.
+type DBTX interface {
+	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
+	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
+	QueryRow(context.Context, string, ...interface{}) pgx.Row
+}

--- a/pkg/sqlstore/impl/user/store.go
+++ b/pkg/sqlstore/impl/user/store.go
@@ -4,28 +4,28 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v4"
-	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/textileio/go-tableland/pkg/sqlstore/impl/transactor"
 )
 
 // UserStore provides access to the db store.
 type UserStore struct {
-	pool *pgxpool.Pool
+	t *transactor.Transactor
 }
 
 // New creates a new UserStore.
-func New(pool *pgxpool.Pool) *UserStore {
-	return &UserStore{pool}
+func New(transactor *transactor.Transactor) *UserStore {
+	return &UserStore{transactor}
 }
 
 // Write executes a write statement on the db.
-func (db *UserStore) Write(ctx context.Context, statement string) error {
-	_, err := db.pool.Exec(ctx, statement)
+func (s *UserStore) Write(ctx context.Context, statement string) error {
+	_, err := s.t.DBTX().Exec(ctx, statement)
 	return err
 }
 
 // Read executes a read statement on the db.
-func (db *UserStore) Read(ctx context.Context, statement string) (interface{}, error) {
-	rows, err := db.pool.Query(ctx, statement, pgx.QuerySimpleProtocol(true))
+func (s *UserStore) Read(ctx context.Context, statement string) (interface{}, error) {
+	rows, err := s.t.DBTX().Query(ctx, statement, pgx.QuerySimpleProtocol(true))
 	if err != nil {
 		return []byte{}, err
 	}

--- a/pkg/sqlstore/sqlstore.go
+++ b/pkg/sqlstore/sqlstore.go
@@ -1,8 +1,15 @@
 package sqlstore
 
+import (
+	"context"
+)
+
 // SQLStore defines the methods for interacting with Tableland storage.
 type SQLStore interface {
 	UserStore
 	SystemStore
+	Begin(context.Context) error
+	Commit(context.Context) error
+	Rollback(context.Context) error
 	Close()
 }


### PR DESCRIPTION
The operation of creating a table in Tableland involves two steps: executing the `CREATE` statement and inserting an entry into the registry table (`system_tables`).

Both steps were not inside a transaction.

Added support for transactions to the `SQLStore` by implementing a `Transactor`. The `Transactor` has the knowledge if there is a transaction running and offers the begin-commit-rollback API and also an API for interacting with the DB (`DBTX`).

Right now there is no support for nested transactions.