### PR TITLE
row decoding: support generic jsons

### DIFF
--- a/pkg/parsing/query_validator.go
+++ b/pkg/parsing/query_validator.go
@@ -110,7 +110,7 @@ var (
 
 		pgtype.UUIDOID: {Oid: pgtype.UUIDOID, GoType: pgtype.UUID{}, Names: []string{"uuid"}},
 
-		pgtype.JSONOID: {Oid: pgtype.JSONOID, GoType: map[string]interface{}{}, Names: []string{"json"}},
+		pgtype.JSONOID: {Oid: pgtype.JSONOID, GoType: pgtype.JSON{}, Names: []string{"json"}},
 	}
 	// TODO: the above list is tentative and incomplete; the accepted types are still not well defined at the spec level.
 

--- a/pkg/sqlstore/impl/user/rowstojson.go
+++ b/pkg/sqlstore/impl/user/rowstojson.go
@@ -51,7 +51,7 @@ func getRowsData(rows pgx.Rows, fields []pgproto3.FieldDescription, nColumns int
 		}
 
 		if err := rows.Scan(scanArgs...); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("scan row column: %s", err)
 		}
 		rowData := make([]interface{}, nColumns)
 		for i := 0; i < nColumns; i++ {

--- a/pkg/sqlstore/impl/user/store_test.go
+++ b/pkg/sqlstore/impl/user/store_test.go
@@ -143,4 +143,28 @@ func TestReadGeneralTypeCorrectness(t *testing.T) {
 		require.NoError(t, err)
 		require.JSONEq(t, `{"columns":[{"name":"json"}],"rows":[[null]]}`, string(b))
 	}
+	// test json map
+	{
+		data, err := execReadQuery(ctx, tx, `SELECT ('{"foo": 1, "bar":"zar"}')::json;`)
+		require.NoError(t, err)
+		b, err := json.Marshal(data)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"columns":[{"name":"json"}],"rows":[[{"bar":"zar","foo":1}]]}`, string(b))
+	}
+	// test json array
+	{
+		data, err := execReadQuery(ctx, tx, `SELECT ('[{"foo": 1}, {"bar":[1,2]}]')::json;`)
+		require.NoError(t, err)
+		b, err := json.Marshal(data)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"columns":[{"name":"json"}],"rows":[[[{"foo":1},{"bar":[1,2]}]]]}`, string(b))
+	}
+	// test json single string
+	{
+		data, err := execReadQuery(ctx, tx, `SELECT ('"iam valid too"')::json;`)
+		require.NoError(t, err)
+		b, err := json.Marshal(data)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"columns":[{"name":"json"}],"rows":[["iam valid too"]]}`, string(b))
+	}
 }


### PR DESCRIPTION
We can use the native `pgtype.JSON` as the base type for generic JSON unmarshaling. This allows supporting any top-level type of JSON.