### PR TITLE
Changes nonce tracker to not rely on disk storage

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -84,6 +84,7 @@ func main() {
 		ctx,
 		wallet,
 		nonceimpl.NewNonceStore(sqlstore),
+		config.Registry.ChainID,
 		conn,
 		checkInterval,
 		config.NonceTracker.MinBlockDepth,

--- a/pkg/nonce/tracker.go
+++ b/pkg/nonce/tracker.go
@@ -10,22 +10,9 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-// Network type is a string that indicates the network.
-type Network string
-
-// EthereumNetwork is referes to Ethereum.
-const EthereumNetwork Network = "eth"
-
-// Nonce represents a nonce for a given address.
-type Nonce struct {
-	Network Network
-	Nonce   int64
-	Address common.Address
-}
-
 // PendingTx represents a pending tx.
 type PendingTx struct {
-	Network   Network
+	ChainID   int64
 	Hash      common.Hash
 	Nonce     int64
 	Address   common.Address
@@ -64,9 +51,7 @@ type ChainClient interface {
 
 // NonceStore provides the api for managing the storage of nonce and pending txs.
 type NonceStore interface {
-	GetNonce(context.Context, Network, common.Address) (Nonce, error)
-	UpsertNonce(context.Context, Network, common.Address, int64) error
-	ListPendingTx(context.Context, Network, common.Address) ([]PendingTx, error)
-	InsertPendingTxAndUpsertNonce(context.Context, Network, common.Address, int64, common.Hash) error
+	ListPendingTx(context.Context, int64, common.Address) ([]PendingTx, error)
+	InsertPendingTx(context.Context, int64, common.Address, int64, common.Hash) error
 	DeletePendingTxByHash(context.Context, common.Hash) error
 }

--- a/pkg/sqlstore/impl/pgx_store_instrumented.go
+++ b/pkg/sqlstore/impl/pgx_store_instrumented.go
@@ -154,54 +154,13 @@ func (s *InstrumentedSQLStorePGX) Read(ctx context.Context, stmt parsing.Sugared
 	return data, err
 }
 
-// GetNonce returns the nonce stored in the database by a given address.
-func (s *InstrumentedSQLStorePGX) GetNonce(
-	ctx context.Context,
-	network string,
-	addr common.Address) (nonce.Nonce, error) {
-	start := time.Now()
-	data, err := s.store.GetNonce(ctx, network, addr)
-	latency := time.Since(start).Milliseconds()
-
-	attributes := []attribute.KeyValue{
-		{Key: "method", Value: attribute.StringValue("GetNonce")},
-		{Key: "success", Value: attribute.BoolValue(err == nil)},
-	}
-
-	s.callCount.Add(ctx, 1, attributes...)
-	s.latencyHistogram.Record(ctx, latency, attributes...)
-
-	return data, err
-}
-
-// UpsertNonce updates a nonce.
-func (s *InstrumentedSQLStorePGX) UpsertNonce(
-	ctx context.Context,
-	network string,
-	addr common.Address,
-	nonce int64) error {
-	start := time.Now()
-	err := s.store.UpsertNonce(ctx, network, addr, nonce)
-	latency := time.Since(start).Milliseconds()
-
-	attributes := []attribute.KeyValue{
-		{Key: "method", Value: attribute.StringValue("UpsertNonce")},
-		{Key: "success", Value: attribute.BoolValue(err == nil)},
-	}
-
-	s.callCount.Add(ctx, 1, attributes...)
-	s.latencyHistogram.Record(ctx, latency, attributes...)
-
-	return err
-}
-
 // ListPendingTx lists all pendings txs.
 func (s *InstrumentedSQLStorePGX) ListPendingTx(
 	ctx context.Context,
-	network string,
+	chainID int64,
 	addr common.Address) ([]nonce.PendingTx, error) {
 	start := time.Now()
-	data, err := s.store.ListPendingTx(ctx, network, addr)
+	data, err := s.store.ListPendingTx(ctx, chainID, addr)
 	latency := time.Since(start).Milliseconds()
 
 	attributes := []attribute.KeyValue{
@@ -218,12 +177,12 @@ func (s *InstrumentedSQLStorePGX) ListPendingTx(
 // InsertPendingTx insert a new pending tx.
 func (s *InstrumentedSQLStorePGX) InsertPendingTx(
 	ctx context.Context,
-	network string,
+	chainID int64,
 	addr common.Address,
 	nonce int64,
 	hash common.Hash) error {
 	start := time.Now()
-	err := s.store.InsertPendingTx(ctx, network, addr, nonce, hash)
+	err := s.store.InsertPendingTx(ctx, chainID, addr, nonce, hash)
 	latency := time.Since(start).Milliseconds()
 
 	attributes := []attribute.KeyValue{

--- a/pkg/sqlstore/impl/pgx_store_throttled.go
+++ b/pkg/sqlstore/impl/pgx_store_throttled.go
@@ -61,39 +61,22 @@ func (s *ThrottledSQLStorePGX) Read(ctx context.Context, stmt parsing.SugaredRea
 	return data, err
 }
 
-// GetNonce returns the nonce stored in the database by a given address.
-func (s *ThrottledSQLStorePGX) GetNonce(
-	ctx context.Context,
-	network string,
-	addr common.Address) (nonce.Nonce, error) {
-	return s.store.GetNonce(ctx, network, addr)
-}
-
-// UpsertNonce updates a nonce.
-func (s *ThrottledSQLStorePGX) UpsertNonce(
-	ctx context.Context,
-	network string,
-	addr common.Address,
-	nonce int64) error {
-	return s.store.UpsertNonce(ctx, network, addr, nonce)
-}
-
 // ListPendingTx lists all pendings txs.
 func (s *ThrottledSQLStorePGX) ListPendingTx(
 	ctx context.Context,
-	network string,
+	chainID int64,
 	addr common.Address) ([]nonce.PendingTx, error) {
-	return s.store.ListPendingTx(ctx, network, addr)
+	return s.store.ListPendingTx(ctx, chainID, addr)
 }
 
 // InsertPendingTx insert a new pending tx.
 func (s *ThrottledSQLStorePGX) InsertPendingTx(
 	ctx context.Context,
-	network string,
+	chainID int64,
 	addr common.Address,
 	nonce int64,
 	hash common.Hash) error {
-	return s.store.InsertPendingTx(ctx, network, addr, nonce, hash)
+	return s.store.InsertPendingTx(ctx, chainID, addr, nonce, hash)
 }
 
 // DeletePendingTxByHash deletes a pending tx.

--- a/pkg/sqlstore/impl/system/internal/db/models.go
+++ b/pkg/sqlstore/impl/system/internal/db/models.go
@@ -33,14 +33,8 @@ type SystemAuth struct {
 	RunSqlCount      int32
 }
 
-type SystemNonce struct {
-	Network string
-	Address string
-	Nonce   int64
-}
-
 type SystemPendingTx struct {
-	Network   string
+	ChainID   int64
 	Address   string
 	Hash      string
 	Nonce     int64

--- a/pkg/sqlstore/impl/system/migrations/009_nonce.down.sql
+++ b/pkg/sqlstore/impl/system/migrations/009_nonce.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE system_nonce;
+DROP TABLE system_pending_tx;

--- a/pkg/sqlstore/impl/system/migrations/009_nonce.up.sql
+++ b/pkg/sqlstore/impl/system/migrations/009_nonce.up.sql
@@ -1,16 +1,9 @@
-CREATE TABLE IF NOT EXISTS system_nonce (
-    network varchar not null,
-    address varchar not null,
-    nonce bigint not null,
-    PRIMARY KEY (network, address)
-);
-
 CREATE TABLE IF NOT EXISTS system_pending_tx (
-    network varchar not null,
+    chain_id bigint not null,
     address varchar not null,
     hash varchar not null, 
     nonce bigint not null,
     created_at timestamp default now() not null,
-    PRIMARY KEY (network, address, nonce)
+    PRIMARY KEY (chain_id, address, nonce)
 );
 

--- a/pkg/sqlstore/impl/system/migrations/migrations.go
+++ b/pkg/sqlstore/impl/system/migrations/migrations.go
@@ -114,7 +114,7 @@ func _001_initDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.down.sql", size: 25, mode: os.FileMode(436), modTime: time.Unix(1639565921, 0)}
+	info := bindataFileInfo{name: "001_init.down.sql", size: 25, mode: os.FileMode(420), modTime: time.Unix(1639484913, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -134,7 +134,7 @@ func _001_initUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "001_init.up.sql", size: 155, mode: os.FileMode(436), modTime: time.Unix(1639565921, 0)}
+	info := bindataFileInfo{name: "001_init.up.sql", size: 155, mode: os.FileMode(420), modTime: time.Unix(1639484913, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -154,7 +154,7 @@ func _002_add_type_columnDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "002_add_type_column.down.sql", size: 43, mode: os.FileMode(436), modTime: time.Unix(1642447553, 0)}
+	info := bindataFileInfo{name: "002_add_type_column.down.sql", size: 43, mode: os.FileMode(420), modTime: time.Unix(1642424618, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -174,7 +174,7 @@ func _002_add_type_columnUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "002_add_type_column.up.sql", size: 65, mode: os.FileMode(436), modTime: time.Unix(1642447553, 0)}
+	info := bindataFileInfo{name: "002_add_type_column.up.sql", size: 65, mode: os.FileMode(420), modTime: time.Unix(1642424618, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -194,7 +194,7 @@ func _003_authDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "003_auth.down.sql", size: 23, mode: os.FileMode(436), modTime: time.Unix(1643658422, 0)}
+	info := bindataFileInfo{name: "003_auth.down.sql", size: 23, mode: os.FileMode(420), modTime: time.Unix(1643380989, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -214,7 +214,7 @@ func _003_authUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "003_auth.up.sql", size: 122, mode: os.FileMode(436), modTime: time.Unix(1643658422, 0)}
+	info := bindataFileInfo{name: "003_auth.up.sql", size: 122, mode: os.FileMode(420), modTime: time.Unix(1643380989, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -234,7 +234,7 @@ func _004_add_last_seenDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "004_add_last_seen.down.sql", size: 106, mode: os.FileMode(436), modTime: time.Unix(1643747041, 0)}
+	info := bindataFileInfo{name: "004_add_last_seen.down.sql", size: 106, mode: os.FileMode(420), modTime: time.Unix(1643807505, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -254,7 +254,7 @@ func _004_add_last_seenUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "004_add_last_seen.up.sql", size: 179, mode: os.FileMode(436), modTime: time.Unix(1643747041, 0)}
+	info := bindataFileInfo{name: "004_add_last_seen.up.sql", size: 179, mode: os.FileMode(420), modTime: time.Unix(1643807505, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -274,7 +274,7 @@ func _005_mul_changesDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "005_mul_changes.down.sql", size: 311, mode: os.FileMode(436), modTime: time.Unix(1644364111, 0)}
+	info := bindataFileInfo{name: "005_mul_changes.down.sql", size: 311, mode: os.FileMode(420), modTime: time.Unix(1644351777, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -294,7 +294,7 @@ func _005_mul_changesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "005_mul_changes.up.sql", size: 495, mode: os.FileMode(436), modTime: time.Unix(1644364111, 0)}
+	info := bindataFileInfo{name: "005_mul_changes.up.sql", size: 495, mode: os.FileMode(420), modTime: time.Unix(1644351777, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -314,7 +314,7 @@ func _006_rename_system_tablesDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "006_rename_system_tables.down.sql", size: 45, mode: os.FileMode(436), modTime: time.Unix(1645722059, 0)}
+	info := bindataFileInfo{name: "006_rename_system_tables.down.sql", size: 45, mode: os.FileMode(420), modTime: time.Unix(1645636858, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -334,7 +334,7 @@ func _006_rename_system_tablesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "006_rename_system_tables.up.sql", size: 45, mode: os.FileMode(436), modTime: time.Unix(1645722059, 0)}
+	info := bindataFileInfo{name: "006_rename_system_tables.up.sql", size: 45, mode: os.FileMode(420), modTime: time.Unix(1645636858, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -354,7 +354,7 @@ func _007_aclDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "007_acl.down.sql", size: 22, mode: os.FileMode(436), modTime: time.Unix(1649682178, 0)}
+	info := bindataFileInfo{name: "007_acl.down.sql", size: 22, mode: os.FileMode(420), modTime: time.Unix(1649686607, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -374,7 +374,7 @@ func _007_aclUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "007_acl.up.sql", size: 397, mode: os.FileMode(436), modTime: time.Unix(1649682178, 0)}
+	info := bindataFileInfo{name: "007_acl.up.sql", size: 397, mode: os.FileMode(420), modTime: time.Unix(1649686607, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -394,7 +394,7 @@ func _008_txn_processorDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "008_txn_processor.down.sql", size: 33, mode: os.FileMode(436), modTime: time.Unix(1649945592, 0)}
+	info := bindataFileInfo{name: "008_txn_processor.down.sql", size: 33, mode: os.FileMode(420), modTime: time.Unix(1650899445, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -414,12 +414,12 @@ func _008_txn_processorUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "008_txn_processor.up.sql", size: 77, mode: os.FileMode(436), modTime: time.Unix(1649945592, 0)}
+	info := bindataFileInfo{name: "008_txn_processor.up.sql", size: 77, mode: os.FileMode(420), modTime: time.Unix(1650899445, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
-var __009_nonceDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x09\xf2\x0f\x50\x08\x71\x74\xf2\x71\x55\x28\xae\x2c\x2e\x49\xcd\x8d\xcf\xcb\xcf\x4b\x4e\xb5\xe6\x02\x04\x00\x00\xff\xff\xf3\x59\xd1\x1b\x19\x00\x00\x00")
+var __009_nonceDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x09\xf2\x0f\x50\x08\x71\x74\xf2\x71\x55\x28\xae\x2c\x2e\x49\xcd\x8d\x2f\x48\xcd\x4b\xc9\xcc\x4b\x8f\x2f\xa9\xb0\xe6\x02\x04\x00\x00\xff\xff\x4e\x9d\x9a\x73\x1e\x00\x00\x00")
 
 func _009_nonceDownSqlBytes() ([]byte, error) {
 	return bindataRead(
@@ -434,12 +434,12 @@ func _009_nonceDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "009_nonce.down.sql", size: 25, mode: os.FileMode(436), modTime: time.Unix(1650392045, 0)}
+	info := bindataFileInfo{name: "009_nonce.down.sql", size: 30, mode: os.FileMode(420), modTime: time.Unix(1651001415, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
 
-var __009_nonceUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xac\x90\xbd\x4e\x85\x40\x10\x85\xfb\x7d\x8a\x53\x42\xc2\x1b\x58\xa1\x59\x13\xe2\x6f\xb8\x5b\x78\x2b\x32\xb2\x23\x6c\x84\x81\xec\x0e\xa2\x6f\x6f\x14\x6d\x34\x86\x98\xdc\xfa\x9b\x9c\x73\xbe\xb9\xa8\x6d\xe9\x2c\x5c\x79\x7e\x6d\x51\x5d\xe2\xf6\xce\xc1\x3e\x54\x07\x77\x40\x7a\x4b\xca\x63\x23\x93\xb4\x8c\xcc\x00\x80\xb0\xae\x53\x7c\xc6\x0b\xc5\xb6\xa7\x08\x99\x14\xb2\x0c\x43\xf1\x49\xc9\xfb\xc8\x29\xfd\x41\xb7\x9c\xc7\xd0\x05\xd1\x1f\xe8\xbe\xae\x6e\xca\xfa\x88\x2b\x7b\x44\xf6\xd5\x51\x7c\xc7\xe5\x26\x3f\x33\x66\x7f\xe7\xcc\xe2\x83\x74\x8d\xbe\x9e\x60\x6c\x4f\xa9\xff\x8d\xb0\x27\xd2\x46\x26\x65\xdf\x90\x42\xc3\xc8\x49\x69\x9c\xe1\xf9\x89\x96\xe1\xe3\x74\xcd\xf2\xff\x98\x17\x5b\xd5\xf6\x80\xf7\x00\x00\x00\xff\xff\xcb\x5a\x18\x9d\xa9\x01\x00\x00")
+var __009_nonceUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x6c\xce\x3b\x4e\xc4\x30\x10\xc6\xf1\xde\xa7\xf8\xca\x44\xca\x0d\xa8\x02\x32\x52\xc4\x53\x59\x17\x6c\x65\x0d\xf6\xb0\xb6\x94\xcc\xae\xec\x09\x8f\xdb\x23\x82\xd2\x04\xea\xdf\x3c\xfe\x37\xa3\xed\x9d\x85\xeb\xaf\xef\x2d\x86\x5b\x3c\x3e\x39\xd8\x97\xe1\xe0\x0e\xa8\x5f\x55\x79\xf6\x17\x96\x98\xe5\xe4\xf5\x13\x8d\x01\x80\x90\x28\x8b\xcf\x11\xaf\xf9\x94\x45\x21\x67\x85\x2c\xd3\xd4\xad\x4a\x31\x16\xae\x15\xef\x54\x42\xa2\xb2\xd3\x44\x35\xfd\x25\xac\x26\x67\x09\xfc\xff\xd1\x50\x98\x94\xa3\x27\x85\xe6\x99\xab\xd2\x7c\x41\xe4\x37\x5a\xa6\x9f\xd1\x8f\xa6\xdd\x2d\x3c\x8f\xc3\x43\x3f\x1e\x71\x67\x8f\x68\xb6\xe0\x6e\x8b\xeb\x7e\x7f\xb5\xa6\xbd\x32\xe6\x3b\x00\x00\xff\xff\xd8\x4e\x48\xa1\x02\x01\x00\x00")
 
 func _009_nonceUpSqlBytes() ([]byte, error) {
 	return bindataRead(
@@ -454,7 +454,7 @@ func _009_nonceUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "009_nonce.up.sql", size: 425, mode: os.FileMode(436), modTime: time.Unix(1650392045, 0)}
+	info := bindataFileInfo{name: "009_nonce.up.sql", size: 258, mode: os.FileMode(420), modTime: time.Unix(1651002137, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -474,7 +474,7 @@ func _010_receiptDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "010_receipt.down.sql", size: 32, mode: os.FileMode(436), modTime: time.Unix(1650489655, 0)}
+	info := bindataFileInfo{name: "010_receipt.down.sql", size: 32, mode: os.FileMode(420), modTime: time.Unix(1650899445, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -494,7 +494,7 @@ func _010_receiptUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "010_receipt.up.sql", size: 228, mode: os.FileMode(436), modTime: time.Unix(1650549778, 0)}
+	info := bindataFileInfo{name: "010_receipt.up.sql", size: 228, mode: os.FileMode(420), modTime: time.Unix(1650899445, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -514,7 +514,7 @@ func _011_new_create_table_flowDownSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "011_new_create_table_flow.down.sql", size: 66, mode: os.FileMode(436), modTime: time.Unix(1650549778, 0)}
+	info := bindataFileInfo{name: "011_new_create_table_flow.down.sql", size: 66, mode: os.FileMode(420), modTime: time.Unix(1650899445, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -534,7 +534,7 @@ func _011_new_create_table_flowUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "011_new_create_table_flow.up.sql", size: 46, mode: os.FileMode(436), modTime: time.Unix(1650549778, 0)}
+	info := bindataFileInfo{name: "011_new_create_table_flow.up.sql", size: 46, mode: os.FileMode(420), modTime: time.Unix(1650899445, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/sqlstore/impl/system/queries/nonce.sql
+++ b/pkg/sqlstore/impl/system/queries/nonce.sql
@@ -1,17 +1,8 @@
--- name: GetNonce :one
-SELECT * FROM system_nonce WHERE address = $1 AND network = $2;
-
--- name: UpsertNonce :exec
-INSERT INTO system_nonce ("network", "address", "nonce") VALUES ($1, $2, $3)
-    ON CONFLICT (network, address)
-    DO UPDATE SET nonce = $3
-    WHERE system_nonce.address = $2 AND system_nonce.network = $1;
-
 -- name: ListPendingTx :many
-SELECT * FROM system_pending_tx WHERE address = $1 AND network = $2;
+SELECT * FROM system_pending_tx WHERE address = $1 AND chain_id = $2;
 
 -- name: InsertPendingTx :exec
-INSERT INTO system_pending_tx ("network", "address", "hash", "nonce") VALUES ($1, $2, $3, $4);
+INSERT INTO system_pending_tx ("chain_id", "address", "hash", "nonce") VALUES ($1, $2, $3, $4);
 
 -- name: DeletePendingTxByHash :exec
 DELETE FROM system_pending_tx WHERE hash = $1;

--- a/pkg/sqlstore/store_system.go
+++ b/pkg/sqlstore/store_system.go
@@ -17,10 +17,8 @@ type SystemStore interface {
 	IncrementCreateTableCount(context.Context, string) error
 	IncrementRunSQLCount(context.Context, string) error
 	GetACLOnTableByController(context.Context, tableland.TableID, string) (SystemACL, error)
-	GetNonce(context.Context, string, common.Address) (nonce.Nonce, error)
-	UpsertNonce(context.Context, string, common.Address, int64) error
-	ListPendingTx(context.Context, string, common.Address) ([]nonce.PendingTx, error)
-	InsertPendingTx(context.Context, string, common.Address, int64, common.Hash) error
+	ListPendingTx(context.Context, int64, common.Address) ([]nonce.PendingTx, error)
+	InsertPendingTx(context.Context, int64, common.Address, int64, common.Hash) error
 	DeletePendingTxByHash(context.Context, common.Hash) error
 	WithTx(tx pgx.Tx) SystemStore
 	Begin(context.Context) (pgx.Tx, error)


### PR DESCRIPTION
Relying on disk storage is a problem. Saving to disk can fail and the value stored in disk may differ from the network value.
The solution was to rely on memory and on initilization always sync with the network.

Also, changes the nonce tracker to be chainID scoped.