### PR TITLE
Reduces MaxBlocksFetchSize to avoid hitting API limits

### DIFF
--- a/local/config-kovan-staging.json
+++ b/local/config-kovan-staging.json
@@ -42,7 +42,7 @@
       "EventFeed": {
         "ChainAPIBackoff": "15s",
         "NewBlockTimeout": "30s",
-        "MaxBlocksFetchSize": 1000000,
+        "MaxBlocksFetchSize": 100000,
         "MinBlockDepth": 0
       },
       "EventProcessor": {


### PR DESCRIPTION
Because of the number of events generated by `Healthbot` so far (`> 20K`) the fetch size we were using (`1000000`) in the `eth_getLogs` calls reached the 10K limit. From Alchemy [docs](https://docs.alchemy.com/alchemy/guides/eth_getlogs):

- You can make eth_getLogs requests with up to a **2K block range** and **150MB limit on the response size** 
- OR you can request **any block range** with a cap of **10K logs in the response**.

We started getting the following error when starting the validator:

```{"level":"warn","version":"cc96df9","goversion":"go1.18.1","component":"eventfeed","chainID":69,"error":"websocket: read limit exceeded","timestamp":"2022-05-12T21:09:28.258747345Z","severity":"Warning","message":"filter logs from 2000001 to 2814946"}```

The `MaxBlocksFetchSize` value was reduced to `100000`, as a short-term measure. 