### PR TITLE
Implements retry when we get nonce too low error

### DIFF
--- a/pkg/nonce/impl/simpletracker.go
+++ b/pkg/nonce/impl/simpletracker.go
@@ -46,7 +46,7 @@ func (t *SimpleTracker) GetPendingCount(ctx context.Context) int {
 	return 0
 }
 
-// Resync resyncs nonce tracker state with the network.
+// Resync is a noop for SimpleTracker.
 func (t *SimpleTracker) Resync(ctx context.Context) error {
 	return nil
 }

--- a/pkg/nonce/impl/tracker.go
+++ b/pkg/nonce/impl/tracker.go
@@ -156,6 +156,7 @@ func (t *LocalTracker) GetPendingCount(_ context.Context) int {
 }
 
 // Resync resyncs nonce tracker state with the network.
+// NOTICE: must not call `Resync(..)` if there are still an "open call" to the method `GetNonce(...)`.
 func (t *LocalTracker) Resync(ctx context.Context) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/pkg/nonce/tracker.go
+++ b/pkg/nonce/tracker.go
@@ -45,6 +45,7 @@ type NonceTracker interface {
 	GetPendingCount(context.Context) int
 
 	// Resync resyncs nonce tracker state with the network.
+	// NOTICE: must not call `Resync(..)` if there are still an "open call" to the method `GetNonce(...)`.
 	Resync(context.Context) error
 }
 

--- a/pkg/tableregistry/impl/ethereum/client.go
+++ b/pkg/tableregistry/impl/ethereum/client.go
@@ -150,12 +150,19 @@ func (c *Client) callWithRetry(ctx context.Context, f func() (*types.Transaction
 			if strings.Contains(err.Error(), errMsg) {
 				log.Warn().Err(err).Msg("retrying smart contract call")
 				if err := c.tracker.Resync(ctx); err != nil {
-					return nil, err
+					return nil, fmt.Errorf("resync: %s", err)
 				}
 				tx, err = f()
+				if err != nil {
+					return nil, fmt.Errorf("retry contract call: %s", err)
+				}
+
+				return tx, nil
 			}
 		}
+
+		return nil, fmt.Errorf("contract call: %s", err)
 	}
 
-	return tx, err
+	return tx, nil
 }

--- a/pkg/tableregistry/impl/ethereum/client_test.go
+++ b/pkg/tableregistry/impl/ethereum/client_test.go
@@ -218,7 +218,7 @@ func TestNonceTooLow(t *testing.T) {
 	// requireMint does a contract call to create a table.
 	// In that process the nonce is increase but the tracker is not aware of it.
 	// This simulates an out of sync nonce.
-	// Try running this test go test -v to see the retry happening.
+	// Try running this test with go test -v to see the retry happening.
 
 	t.Run("run-sql", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
We started seeing the error `health check: increasing counter value: calling tableland_runSQL: sending tx: calling RunSQL: invalid transaction: nonce too low"` in the logs. 

Although it's not really clear the causes for this, we know that the local nonce tracker can get out of sync in some situations. For example:
- If someone uses the same private key to make calls in another place. The validator will not be aware of that nonce increase and will get out of sync. And we may get this error.
- If a contract call went through, but we still got an error on our side (typical unreliable network issue)

This happens because we opted to keep the nonce in memory and avoid a network call to get the nonce in every contract call.

This PR, implements a retry mechanism for the `RunSQL` and `SetController` contract calls every time it encounters the errors `"nonce too low"` and `"invalid transaction nonce"`.