### PR TITLE
Fix hardhat chainId

### DIFF
--- a/local/config-dev.json
+++ b/local/config-dev.json
@@ -2,7 +2,7 @@
   "Chains": [
     {
       "Name": "Local Hardhat",
-      "ChainID": 1337,
+      "ChainID": 31337,
       "Registry": {
         "EthEndpoint": "ws://host.docker.internal:8545",
         "ContractAddress": "[FILL ME]"


### PR DESCRIPTION
Looks like there may have been a typo in `local/config-dev.json`.  Hardhat's default chain id is 31337