### PR TITLE
local/config-dev.json works with default local hardhat node

### DIFF
--- a/local/config-dev.json
+++ b/local/config-dev.json
@@ -5,7 +5,7 @@
       "ChainID": 31337,
       "Registry": {
         "EthEndpoint": "ws://host.docker.internal:8545",
-        "ContractAddress": "0x5fbdb2315678afecb367f032d93f642f64180aa3"
+        "ContractAddress": "[FILL ME]"
       },
       "Signer": {
         "PrivateKey": "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"


### PR DESCRIPTION
Here are a few changes to get `cd local && make up` to work with the default settings for a local Hardhat node.
This is related to getting Hardhat to emit the event logs corrently, more detail here: https://github.com/tablelandnetwork/eth-tableland/pull/15
Also, the SDK end-to-end tests here: https://github.com/textileio/local-tableland

I put a few inline comments explaining my thinking, but I'm not overly familiar with this code base so these changes may not make total sense.