### PR TITLE
tooling: CLI for bumping txn fees

### DIFF
--- a/cmd/gaspricebumper/main.go
+++ b/cmd/gaspricebumper/main.go
@@ -45,7 +45,6 @@ func bumpTxnFee(
 	conn *ethclient.Client,
 	pk *ecdsa.PrivateKey,
 	stuckTxnHash common.Hash) (common.Hash, error) {
-
 	ctx := context.Background()
 
 	pendingTxn, isPending, err := conn.TransactionByHash(ctx, stuckTxnHash)


### PR DESCRIPTION
This PR is some middle point compared to #118.

As an example, we can do the following to bump by 25% the gas price of a stuck txn in RInkeby:
`go run ./cmd/gaspricebumper/... -ethendpoint wss://rinkeby.infura.io/ws/v3/<auth> -privatekey <priv-key-hex> <txn-hash-hex>`
(i.e: two flags, and the first argument is the stuck txn hash)

Of course, the same will work with any EVM chain.

I've tested this live in Rinkeby creating some txn with very low fees and had to bump it 4 times to get it unstuck. The 4 times it happened what was expected, so it works.

We can drop some words in the runbook, or maybe probably we should only restrict using this to us for a while.