### PR TITLE
[shipit] Accepts varchar[]

### DIFF
--- a/pkg/parsing/query_validator.go
+++ b/pkg/parsing/query_validator.go
@@ -139,6 +139,8 @@ var (
 		pgtype.UUIDOID: {Oid: pgtype.UUIDOID, GoType: pgtype.UUID{}, Names: []string{"uuid"}},
 
 		pgtype.JSONOID: {Oid: pgtype.JSONOID, GoType: pgtype.JSON{}, Names: []string{"json"}},
+
+		pgtype.VarcharArrayOID: {Oid: pgtype.VarcharArrayOID, GoType: pgtype.VarcharArray{}, Names: []string{"varchar[]"}},
 	}
 	// TODO: the above list is tentative and incomplete; the accepted types are still not well defined at the spec level.
 

--- a/pkg/sqlstore/impl/user/rowstojson.go
+++ b/pkg/sqlstore/impl/user/rowstojson.go
@@ -120,6 +120,16 @@ func getValueFromScanArg(arg interface{}) (interface{}, error) {
 			buf, _ = val.EncodeText(pgtype.NewConnInfo(), buf)
 			return string(buf), nil
 		}
+
+		if val, ok := (arg).(*pgtype.VarcharArray); ok {
+			if val.Status == pgtype.Null {
+				return nil, nil
+			}
+
+			buf := make([]byte, 0)
+			buf, _ = val.EncodeText(pgtype.NewConnInfo(), buf)
+			return string(buf), nil
+		}
 	}
 
 	return arg, nil


### PR DESCRIPTION
This PR is to allow users to query the `privileges` from the `system_acl`. Since `privileges` is of `[]varchar` type we must `varchar[]`. We have to be mindful that's a type we won't support in SQLite, so we can't encourage users to use it.