### PR TITLE
processor: new error code for invalid bytes query

### DIFF
--- a/pkg/txn/impl/processor.go
+++ b/pkg/txn/impl/processor.go
@@ -393,6 +393,9 @@ func (b *batch) SaveTxnReceipts(ctx context.Context, rs []eventprocessor.Receipt
 					return fmt.Errorf("parsing table id to numeric: %s", err)
 				}
 			}
+			if r.Error != nil {
+				*r.Error = strings.ToValidUTF8(*r.Error, "")
+			}
 			if _, err := tx.Exec(
 				ctx,
 				`INSERT INTO system_txn_receipts (chain_id, txn_hash, error, table_id, block_number) 


### PR DESCRIPTION
This PR contemplates the situation that the queries aren't valid UTF8 strings, which makes Postgres return an error not only in the query execution but also in embedded strings when saving the receipt.