### PR TITLE
k8/healthbot: check every 1hr for Goerli

### DIFF
--- a/k8/testnet/config-healthbot-testnet.json
+++ b/k8/testnet/config-healthbot-testnet.json
@@ -20,7 +20,7 @@
         {
             "Name": "ethereum-goerli",
             "Probe": {
-                "CheckInterval": "60s",
+                "CheckInterval": "1h",
                 "ReceiptTimeout": "90s",
                 "SIWE": "${HEALTHBOT_ETHEREUM_GOERLI_SIWE}",
                 "Tablename": "Healthbot_5_0"


### PR DESCRIPTION
The burnrate of our free funds in Goerli is slower than our check interval, at this pace we will run out of funds before being able to claim funds again so switching the interval to something more sustainable.