### PR TITLE
fix: typo setting MaxTextLength to wrong value

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -63,7 +63,7 @@ func main() {
 
 	parserOpts := []parsing.Option{
 		parsing.WithMaxAllowedColumns(config.TableConstraints.MaxColumns),
-		parsing.WithMaxTextLength(config.TableConstraints.MaxColumns),
+		parsing.WithMaxTextLength(config.TableConstraints.MaxTextLength),
 		parsing.WithMaxReadQuerySize(config.QueryConstraints.MaxReadQuerySize),
 		parsing.WithMaxWriteQuerySize(config.QueryConstraints.MaxWriteQuerySize),
 	}


### PR DESCRIPTION
Looks like there may have been a typo that is causing the max text length to be set to the max column length