### PR TITLE
parser: disallow sqlite_ prefix in create tables

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -60,7 +60,11 @@ func main() {
 		parsing.WithMaxWriteQuerySize(config.QueryConstraints.MaxWriteQuerySize),
 	}
 
-	parser, err := parserimpl.New([]string{systemimpl.SystemTablesPrefix, systemimpl.RegistryTableName}, parserOpts...)
+	parser, err := parserimpl.New([]string{
+		"sqlite_",
+		systemimpl.SystemTablesPrefix,
+		systemimpl.RegistryTableName,
+	}, parserOpts...)
 	if err != nil {
 		log.Fatal().Err(err).Msg("new parser")
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sethvargo/go-limiter v0.7.2
 	github.com/spruceid/siwe-go v0.2.0
 	github.com/stretchr/testify v1.7.4
-	github.com/tablelandnetwork/sqlparser v0.0.0-20220706201905-0ca67a566c4e
+	github.com/tablelandnetwork/sqlparser v0.0.0-20220706202446-651da656fce8
 	github.com/textileio/cli v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.32.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -1271,8 +1271,8 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
-github.com/tablelandnetwork/sqlparser v0.0.0-20220706201905-0ca67a566c4e h1:+Bxk/NJgaJSLCaje0ehhL3hb6yOF7FpSiz0VSmp8QRI=
-github.com/tablelandnetwork/sqlparser v0.0.0-20220706201905-0ca67a566c4e/go.mod h1:GneggLILTJ6yM9xfBXu4OSZ0bfc/8Cw/PkzDfawhhkg=
+github.com/tablelandnetwork/sqlparser v0.0.0-20220706202446-651da656fce8 h1:0mcnXoayzxj8iopdjQ6NizPcLxMrxyTFeDwhsWUbKqc=
+github.com/tablelandnetwork/sqlparser v0.0.0-20220706202446-651da656fce8/go.mod h1:GneggLILTJ6yM9xfBXu4OSZ0bfc/8Cw/PkzDfawhhkg=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/textileio/cli v1.0.2 h1:qSp/x4d/9SZ93TxhgZnE5okRKqzqHqrzAwKAPjuPw50=
 github.com/textileio/cli v1.0.2/go.mod h1:vTlCvvVyOmXXLwddCcBg3PDavfUsCkRBZoyr6Nu1lkc=

--- a/internal/router/controllers/user_test.go
+++ b/internal/router/controllers/user_test.go
@@ -161,13 +161,13 @@ func (rm *runnerMock) RunReadQuery(
 		str := "foo"
 		ptrStr := &str
 		return tableland.RunReadQueryResponse{
-			Result: sqlstore.UserRows{
+			Result: &sqlstore.UserRows{
 				Rows: [][]interface{}{{&ptrStr}},
 			},
 		}, nil
 	}
 	return tableland.RunReadQueryResponse{
-		Result: sqlstore.UserRows{
+		Result: &sqlstore.UserRows{
 			Columns: []sqlstore.UserColumn{
 				{Name: "id"},
 				{Name: "description"},
@@ -220,7 +220,7 @@ func (*notFoundRunnerMock) RunReadQuery(
 	ctx context.Context,
 	req tableland.RunReadQueryRequest) (tableland.RunReadQueryResponse, error) {
 	return tableland.RunReadQueryResponse{
-		Result: sqlstore.UserRows{
+		Result: &sqlstore.UserRows{
 			Columns: []sqlstore.UserColumn{
 				{Name: "id"},
 				{Name: "description"},
@@ -247,7 +247,7 @@ func (rm *queryRunnerMock) RunReadQuery(
 	ctx context.Context,
 	req tableland.RunReadQueryRequest) (tableland.RunReadQueryResponse, error) {
 	return tableland.RunReadQueryResponse{
-		Result: sqlstore.UserRows{
+		Result: &sqlstore.UserRows{
 			Columns: []sqlstore.UserColumn{
 				{Name: "id"},
 				{Name: "eyes"},


### PR DESCRIPTION
We were missing disallowing `sqlite_` prefixes in table names. We had tests to exactly test this behavior, but in the main configuration we missed adding it.