### PR TITLE
eventfeed: only allow to process one event per txn

### DIFF
--- a/pkg/eventprocessor/eventfeed/impl/eventfeed.go
+++ b/pkg/eventprocessor/eventfeed/impl/eventfeed.go
@@ -147,7 +147,8 @@ func (ef *EventFeed) Start(
 				// If we got an error here, log it but allow to be retried
 				// in the next head. Probably the API can have transient unavailability.
 				ef.log.Warn().Err(err).Msgf("filter logs from %d to %d", fromHeight, toHeight)
-				if strings.Contains(err.Error(), "read limit exceeded") {
+				if strings.Contains(err.Error(), "read limit exceeded") ||
+					strings.Contains(err.Error(), "is greater than the limit") {
 					ef.maxBlocksFetchSize = ef.maxBlocksFetchSize * 80 / 100
 				} else {
 					time.Sleep(ef.config.ChainAPIBackoff)

--- a/pkg/eventprocessor/eventfeed/impl/eventfeed.go
+++ b/pkg/eventprocessor/eventfeed/impl/eventfeed.go
@@ -162,13 +162,19 @@ func (ef *EventFeed) Start(
 				bq := eventfeed.BlockEvents{
 					BlockNumber: int64(logs[0].BlockNumber),
 				}
+				observedTxns := map[string]struct{}{}
 				for _, l := range logs {
 					if bq.BlockNumber != int64(l.BlockNumber) {
 						ch <- bq
 						bq = eventfeed.BlockEvents{
 							BlockNumber: int64(l.BlockNumber),
 						}
+						observedTxns = map[string]struct{}{}
 					}
+					if _, ok := observedTxns[l.TxHash.Hex()]; ok {
+						continue
+					}
+					observedTxns[l.TxHash.Hex()] = struct{}{}
 
 					event, err := ef.parseEvent(l)
 					if err != nil {

--- a/pkg/eventprocessor/eventfeed/impl/eventfeed.go
+++ b/pkg/eventprocessor/eventfeed/impl/eventfeed.go
@@ -172,6 +172,7 @@ func (ef *EventFeed) Start(
 						observedTxns = map[string]struct{}{}
 					}
 					if _, ok := observedTxns[l.TxHash.Hex()]; ok {
+						ef.log.Warn().Str("txnHash", l.TxHash.String()).Msg("txn has more than one event")
 						continue
 					}
 					observedTxns[l.TxHash.Hex()] = struct{}{}


### PR DESCRIPTION
The current SC allows emitting more than one event per txn, which isn't allowed today.
We need to handle this case since that would violate a PRIMARY KEY.