### PR TITLE
eventfeed: avoid pitfall in ethclient of returning a typed nil

### DIFF
--- a/pkg/eventprocessor/eventfeed/impl/eventfeed.go
+++ b/pkg/eventprocessor/eventfeed/impl/eventfeed.go
@@ -317,6 +317,7 @@ func (ef *EventFeed) notifyNewBlocks(ctx context.Context, clientCh chan *types.H
 			}
 			sub, err = ef.ethClient.SubscribeNewHead(ctx, ch)
 			if err != nil {
+				sub = nil
 				ef.log.Error().Err(err).Msg("subscribing to blocks")
 				continue
 			}


### PR DESCRIPTION
While doing some cold syncing I noticed a panic which was quite strange.

Turns out the ethclient new subscription can return typed nil, thus interfering with `!= nil` checks.
This is a usually hairy pitfall.