### PR TITLE
healthbot: avoid false first values

### DIFF
--- a/cmd/healthbot/counterprobe/metrics.go
+++ b/cmd/healthbot/counterprobe/metrics.go
@@ -39,9 +39,13 @@ func (cp *CounterProbe) initMetrics(chainName string) error {
 		cp.lock.RLock()
 		defer cp.lock.RUnlock()
 
-		mLastCheck.Observe(ctx, cp.mLastCheck.Unix(), cp.mBaseLabels...)
-		mLastSuccessfulCheck.Observe(ctx, cp.mLastSuccessfulCheck.Unix(), cp.mBaseLabels...)
-		mCounterValue.Observe(ctx, cp.mLastCounterValue, cp.mBaseLabels...)
+		if !cp.mLastCheck.IsZero() {
+			mLastCheck.Observe(ctx, cp.mLastCheck.Unix(), cp.mBaseLabels...)
+		}
+		if !cp.mLastSuccessfulCheck.IsZero() {
+			mLastSuccessfulCheck.Observe(ctx, cp.mLastSuccessfulCheck.Unix(), cp.mBaseLabels...)
+			mCounterValue.Observe(ctx, cp.mLastCounterValue, cp.mBaseLabels...)
+		}
 	}); err != nil {
 		return fmt.Errorf("registering callback on instruments: %s", err)
 	}


### PR DESCRIPTION
Adjust only observing new values in healthbot if they're true measurements to avoid false alarms.

Probably, we need to do something similar in other metrics in general (e.g: wallet balances). That might require some refactoring to make them pointers and use `nil` as the signal for no-value, or initialize them as -1 or similar.