### PR TITLE
Add logging middleware & disable HTTP2 & extra nits

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -110,6 +110,7 @@ func main() {
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 20 * time.Second,
 		IdleTimeout:  120 * time.Second,
+		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 		Handler:      router.Handler(),
 	}
 

--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -2,7 +2,7 @@
     "Impl": "mesa",
     "HTTP": {
         "Port": "8080",
-        "RateLimInterval": "4s",
+        "RateLimInterval": "2s",
         "MaxRequestPerInterval": 10,
         "TLSCert": "${VALIDATOR_TLS_CERT}",
         "TLSKey": "${VALIDATOR_TLS_KEY}"

--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -2,7 +2,7 @@
     "Impl": "mesa",
     "HTTP": {
         "Port": "8080",
-        "RateLimInterval": "1s",
+        "RateLimInterval": "4s",
         "MaxRequestPerInterval": 10,
         "TLSCert": "${VALIDATOR_TLS_CERT}",
         "TLSKey": "${VALIDATOR_TLS_KEY}"

--- a/docker/deployed/testnet/healthbot/config.json
+++ b/docker/deployed/testnet/healthbot/config.json
@@ -11,7 +11,7 @@
         {
             "Name": "optimism-kovan",
             "Probe": {
-                "CheckInterval": "30s",
+                "CheckInterval": "60s",
                 "ReceiptTimeout": "25s",
                 "SIWE": "${HEALTHBOT_OPTIMISM_KOVAN_SIWE}",
                 "Tablename": "${HEALTHBOT_OPTIMISM_KOVAN_TABLE}"

--- a/internal/router/controllers/user.go
+++ b/internal/router/controllers/user.go
@@ -329,7 +329,8 @@ func (c *UserController) runReadRequest(
 		log.Ctx(ctx).
 			Error().
 			Str("sqlRequest", req.Statement).
-			Err(err)
+			Err(err).
+			Msg("executing read query")
 
 		_ = json.NewEncoder(rw).Encode(errors.ServiceError{Message: err.Error()})
 		return nil, false

--- a/internal/router/middlewares/logging.go
+++ b/internal/router/middlewares/logging.go
@@ -8,14 +8,22 @@ import (
 
 // WithLogging logs requests and responses that contain useful information.
 func WithLogging(h http.Handler) http.Handler {
-	handler := func(rw http.ResponseWriter, req *http.Request) {
+	handler := func(rw http.ResponseWriter, r *http.Request) {
 		loggedRW := &responseWriterLogger{
 			ResponseWriter: rw,
 		}
-		h.ServeHTTP(loggedRW, req)
+		h.ServeHTTP(loggedRW, r)
 
 		if loggedRW.statusCode != http.StatusOK {
-			log.Warn().Int("statusCode", loggedRW.statusCode).Msg("non-200 status code response")
+			clientIP, err := extractClientIP(r)
+			if err != nil {
+				log.Warn().Err(err).Msg("can't extract client ip")
+				clientIP = "none"
+			}
+			log.Warn().
+				Int("statusCode", loggedRW.statusCode).
+				Str("clientIP", clientIP).
+				Msg("non-200 status code response")
 		}
 	}
 	return http.HandlerFunc(handler)

--- a/internal/router/middlewares/logging.go
+++ b/internal/router/middlewares/logging.go
@@ -1,0 +1,32 @@
+package middlewares
+
+import (
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+)
+
+// WithLogging logs requests and responses that contain useful information.
+func WithLogging(h http.Handler) http.Handler {
+	handler := func(rw http.ResponseWriter, req *http.Request) {
+		loggedRW := &responseWriterLogger{
+			ResponseWriter: rw,
+		}
+		h.ServeHTTP(loggedRW, req)
+
+		if loggedRW.statusCode != http.StatusOK {
+			log.Warn().Int("statusCode", loggedRW.statusCode).Msg("non-200 status code response")
+		}
+	}
+	return http.HandlerFunc(handler)
+}
+
+type responseWriterLogger struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (r *responseWriterLogger) WriteHeader(statusCode int) {
+	r.ResponseWriter.WriteHeader(statusCode)
+	r.statusCode = statusCode
+}

--- a/internal/router/middlewares/logging.go
+++ b/internal/router/middlewares/logging.go
@@ -20,7 +20,8 @@ func WithLogging(h http.Handler) http.Handler {
 				log.Warn().Err(err).Msg("can't extract client ip")
 				clientIP = "none"
 			}
-			log.Warn().
+			log.Ctx(r.Context()).
+				Warn().
 				Int("statusCode", loggedRW.statusCode).
 				Str("clientIP", clientIP).
 				Msg("non-200 status code response")

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -78,14 +78,14 @@ func ConfiguredRouter(
 
 	router.Post("/rpc", func(rw http.ResponseWriter, r *http.Request) {
 		server.ServeHTTP(rw, r)
-	}, middlewares.Authentication, rateLim, middlewares.OtelHTTP("rpc"))
+	}, middlewares.WithLogging, middlewares.Authentication, rateLim, middlewares.OtelHTTP("rpc"))
 
 	// Gateway configuration.
-	router.Get("/chain/{chainID}/tables/{id}", systemController.GetTable, middlewares.RESTChainID, rateLim, middlewares.OtelHTTP("GetTable"))                                           // nolint
-	router.Get("/chain/{chainID}/tables/{id}/{key}/{value}", userController.GetTableRow, middlewares.RESTChainID, rateLim, middlewares.OtelHTTP("GetTableRow"))                         // nolint
-	router.Get("/chain/{chainID}/tables/controller/{address}", systemController.GetTablesByController, middlewares.RESTChainID, rateLim, middlewares.OtelHTTP("GetTablesByController")) // nolint
-	router.Get("/query", userController.GetTableQuery, rateLim, middlewares.OtelHTTP("GetTableQuery"))                                                                                  // nolint
-	router.Get("/version", infraController.Version, rateLim, middlewares.OtelHTTP("Version"))                                                                                           // nolint
+	router.Get("/chain/{chainID}/tables/{id}", systemController.GetTable, middlewares.WithLogging, middlewares.RESTChainID, rateLim, middlewares.OtelHTTP("GetTable"))                                           // nolint
+	router.Get("/chain/{chainID}/tables/{id}/{key}/{value}", userController.GetTableRow, middlewares.WithLogging, middlewares.RESTChainID, rateLim, middlewares.OtelHTTP("GetTableRow"))                         // nolint
+	router.Get("/chain/{chainID}/tables/controller/{address}", systemController.GetTablesByController, middlewares.WithLogging, middlewares.RESTChainID, rateLim, middlewares.OtelHTTP("GetTablesByController")) // nolint
+	router.Get("/query", userController.GetTableQuery, middlewares.WithLogging, rateLim, middlewares.OtelHTTP("GetTableQuery"))                                                                                  // nolint
+	router.Get("/version", infraController.Version, middlewares.WithLogging, rateLim, middlewares.OtelHTTP("Version"))                                                                                           // nolint
 
 	// Health endpoint configuration.
 	router.Get("/healthz", healthHandler)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -78,14 +78,14 @@ func ConfiguredRouter(
 
 	router.Post("/rpc", func(rw http.ResponseWriter, r *http.Request) {
 		server.ServeHTTP(rw, r)
-	}, middlewares.WithLogging, middlewares.Authentication, rateLim, middlewares.OtelHTTP("rpc"))
+	}, middlewares.WithLogging, middlewares.OtelHTTP("rpc"), middlewares.Authentication, rateLim)
 
 	// Gateway configuration.
-	router.Get("/chain/{chainID}/tables/{id}", systemController.GetTable, middlewares.WithLogging, middlewares.RESTChainID, rateLim, middlewares.OtelHTTP("GetTable"))                                           // nolint
-	router.Get("/chain/{chainID}/tables/{id}/{key}/{value}", userController.GetTableRow, middlewares.WithLogging, middlewares.RESTChainID, rateLim, middlewares.OtelHTTP("GetTableRow"))                         // nolint
-	router.Get("/chain/{chainID}/tables/controller/{address}", systemController.GetTablesByController, middlewares.WithLogging, middlewares.RESTChainID, rateLim, middlewares.OtelHTTP("GetTablesByController")) // nolint
-	router.Get("/query", userController.GetTableQuery, middlewares.WithLogging, rateLim, middlewares.OtelHTTP("GetTableQuery"))                                                                                  // nolint
-	router.Get("/version", infraController.Version, middlewares.WithLogging, rateLim, middlewares.OtelHTTP("Version"))                                                                                           // nolint
+	router.Get("/chain/{chainID}/tables/{id}", systemController.GetTable, middlewares.WithLogging, middlewares.OtelHTTP("GetTable"), middlewares.RESTChainID, rateLim)                                           // nolint
+	router.Get("/chain/{chainID}/tables/{id}/{key}/{value}", userController.GetTableRow, middlewares.WithLogging, middlewares.OtelHTTP("GetTableRow"), middlewares.RESTChainID, rateLim)                         // nolint
+	router.Get("/chain/{chainID}/tables/controller/{address}", systemController.GetTablesByController, middlewares.WithLogging, middlewares.OtelHTTP("GetTablesByController"), middlewares.RESTChainID, rateLim) // nolint
+	router.Get("/query", userController.GetTableQuery, middlewares.WithLogging, middlewares.OtelHTTP("GetTableQuery"), rateLim)                                                                                  // nolint
+	router.Get("/version", infraController.Version, middlewares.WithLogging, middlewares.OtelHTTP("Version"), rateLim)                                                                                           // nolint
 
 	// Health endpoint configuration.
 	router.Get("/healthz", healthHandler)


### PR DESCRIPTION
This PR:
- Adds a new logging middleware that logs any non-200 response. This will be useful to dig into some weird requests we're seeing.
- DIsable HTTP2, which Cloudflare proxy doesn't like produces 520 responses from their side.
- The User Controller was missing a `Msg` call in logs in an error path, not producing a particular log line.
- Reduce a bit the frequency of Kovan probes.