### PR TITLE
Fixes transfer event execution

### DIFF
--- a/internal/tableland/impl/mesa_test.go
+++ b/internal/tableland/impl/mesa_test.go
@@ -453,6 +453,19 @@ func TestTransferTable(t *testing.T) {
 		100*time.Millisecond,
 	)
 	requireReceipts(ctx, t, tbldOwner2, []string{r2.Transaction.Hash}, true)
+
+	// check registry table new ownership
+	require.Eventually(t,
+		runSQLCountEq(ctx,
+			t,
+			tbldOwner2,
+			fmt.Sprintf("SELECT * FROM registry WHERE controller = '%s' AND id = 1 AND chain_id = 1337", txOptsOwner2.From.Hex()), // nolint
+			txOptsOwner2.From.Hex(),
+			1,
+		),
+		5*time.Second,
+		100*time.Millisecond,
+	)
 }
 
 func TestQueryConstraints(t *testing.T) {

--- a/pkg/txn/txn.go
+++ b/pkg/txn/txn.go
@@ -66,6 +66,8 @@ type Batch interface {
 	SaveTxnReceipts(ctx context.Context, rs []eventprocessor.Receipt) error
 	TxnReceiptExists(ctx context.Context, txnHash common.Hash) (bool, error)
 
+	ChangeTableOwner(ctx context.Context, id tableland.TableID, newOwner common.Address) error
+
 	Commit() error
 	Close() error
 }


### PR DESCRIPTION
# Summary

The execution of a transfer event was not changing the table's owner in the registry table.

# Context

[Two tables were transferred on Goerli](https://goerli.etherscan.io/address/0x0C53611b433B486ec940334653F7756D75147dEA#tokentxnsErc721) (57 and 59) to address `0x0C53611b433B486ec940334653F7756D75147dEA`, but when executing the call `https://testnet.tableland.network/chain/5/tables/controller/0x0C53611b433B486ec940334653F7756D75147dEA` you could not see those tables listed.

The undesired behavior happened because of a missing logic when executing the transfer event logic. 

## More info

- I already synced from scratch locally (pointing to `testnet` contract) and the logic worked. 
- Deployed to staging
- Even after this PR is merged and deployed to `testnet`, we'll need to sync all events from scratch to pick up the change (that will probably be done in a future time)


cc @sanderpick 