### PR TITLE
testnet: restore original rate limit

### DIFF
--- a/docker/deployed/staging/api/config.json
+++ b/docker/deployed/staging/api/config.json
@@ -13,7 +13,7 @@
     "Port": "5432"
   },
   "TableConstraints": {
-    "MaxRowCount": 100000
+    "MaxRowCount": 500000
   },
   "QueryConstraints": {
     "MaxWriteQuerySize": 35000,

--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -14,7 +14,7 @@
         "Port": "5432"
     },
     "TableConstraints": {
-        "MaxRowCount": 100000
+        "MaxRowCount": 500000
     },
     "QueryConstraints": {
         "MaxWriteQuerySize": 35000,

--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -2,7 +2,7 @@
     "Impl": "mesa",
     "HTTP": {
         "Port": "8080",
-        "RateLimInterval": "2s",
+        "RateLimInterval": "1s",
         "MaxRequestPerInterval": 10,
         "TLSCert": "${VALIDATOR_TLS_CERT}",
         "TLSKey": "${VALIDATOR_TLS_KEY}"


### PR DESCRIPTION
This PR:
- Bumps rate-limiting to the original rate now that CF is doing the heavy lifting on bad cases.
- Bumps table row limit to 500k as decided in TPD.