### PR TITLE
tls: tune configuration for CF

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -137,6 +137,12 @@ func main() {
 			}
 			server.TLSConfig = &tls.Config{
 				Certificates: []tls.Certificate{cert},
+				MinVersion:   tls.VersionTLS13,
+				CipherSuites: []uint16{
+					tls.TLS_AES_128_GCM_SHA256,
+					tls.TLS_AES_256_GCM_SHA384,
+					tls.TLS_CHACHA20_POLY1305_SHA256,
+				},
 			}
 
 			server.Addr = ":443"


### PR DESCRIPTION
I got a message from CF that we might be accepting TLS ciphers that aren't aligned with what they expect.

Now set ciphers to match [their official documentation](https://developers.cloudflare.com/ssl/origin-configuration/cipher-suites/) to see if this impacts them.

After we figure out if it does (or not), we can see later to revert or make this an optional flag. For now, take this as giving it a try to fix the 520 from CF.