### PR TITLE
Updates to most recent version of the parser [stagingdeploy]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/spruceid/siwe-go v0.2.1-0.20220711143404-817846826282
 	github.com/stretchr/testify v1.8.0
-	github.com/tablelandnetwork/sqlparser v0.0.0-20220706202446-651da656fce8
+	github.com/tablelandnetwork/sqlparser v0.0.0-20220724131240-e324c674632c
 	github.com/textileio/cli v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.32.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -1287,8 +1287,8 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a h1:1ur3QoCqvE5fl+nylMaIr9PVV1w343YRDtsy+Rwu7XI=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
-github.com/tablelandnetwork/sqlparser v0.0.0-20220706202446-651da656fce8 h1:0mcnXoayzxj8iopdjQ6NizPcLxMrxyTFeDwhsWUbKqc=
-github.com/tablelandnetwork/sqlparser v0.0.0-20220706202446-651da656fce8/go.mod h1:GneggLILTJ6yM9xfBXu4OSZ0bfc/8Cw/PkzDfawhhkg=
+github.com/tablelandnetwork/sqlparser v0.0.0-20220724131240-e324c674632c h1:iOGVItskC65cypzlXiXorESrXY5SjV/eQdVuo06sVTU=
+github.com/tablelandnetwork/sqlparser v0.0.0-20220724131240-e324c674632c/go.mod h1:tiNXABmR9dWeLDts7u2l6onz2sH9isfctTnUOakplAU=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/textileio/cli v1.0.2 h1:qSp/x4d/9SZ93TxhgZnE5okRKqzqHqrzAwKAPjuPw50=
 github.com/textileio/cli v1.0.2/go.mod h1:vTlCvvVyOmXXLwddCcBg3PDavfUsCkRBZoyr6Nu1lkc=

--- a/pkg/parsing/impl/validator_test.go
+++ b/pkg/parsing/impl/validator_test.go
@@ -535,6 +535,14 @@ func TestCreateTableChecks(t *testing.T) {
 			query:      "delete from foo",
 			expErrType: ptr2ErrNoTopLevelCreate(),
 		},
+
+		// reserved keywords
+		{
+			name:       "keyword references",
+			query:      "create table any_1337 (references text);",
+			chainID:    1337,
+			expErrType: ptr2ErrKeywordIsNotAllowed(),
+		},
 	}
 
 	for _, it := range tests {
@@ -904,6 +912,11 @@ func ptr2ErrSystemTableReferencing() **parsing.ErrSystemTableReferencing {
 }
 
 func ptr2ErrNonDeterministicFunction() **sqlparser.ErrKeywordIsNotAllowed {
+	var e *sqlparser.ErrKeywordIsNotAllowed
+	return &e
+}
+
+func ptr2ErrKeywordIsNotAllowed() **sqlparser.ErrKeywordIsNotAllowed {
 	var e *sqlparser.ErrKeywordIsNotAllowed
 	return &e
 }


### PR DESCRIPTION
REFERENCES is a keyword that is not allowed as identifier. This was causing the validator to be stuck.

Signed-off-by: Bruno Calza <brunoangelicalza@gmail.com>