### PR TITLE
Adds SVG renderer to table metadata

### DIFF
--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -28,7 +28,8 @@ type config struct {
 		MaxRequestPerInterval uint64 `default:"10"`
 	}
 	Gateway struct {
-		ExternalURIPrefix string `default:"https://testnet.tableland.network"`
+		ExternalURIPrefix   string `default:"https://testnet.tableland.network"`
+		MetadataRendererURI string `default:"https://render.tableland.xyz"`
 	}
 	TableConstraints TableConstraints
 	QueryConstraints QueryConstraints

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -29,7 +29,7 @@ type config struct {
 	}
 	Gateway struct {
 		ExternalURIPrefix   string `default:"https://testnet.tableland.network"`
-		MetadataRendererURI string `default:"https://render.tableland.xyz"`
+		MetadataRendererURI string `default:""`
 	}
 	TableConstraints TableConstraints
 	QueryConstraints QueryConstraints

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -97,6 +97,7 @@ func main() {
 
 	router := router.ConfiguredRouter(
 		config.Gateway.ExternalURIPrefix,
+		config.Gateway.MetadataRendererURI,
 		config.HTTP.MaxRequestPerInterval,
 		rateLimInterval,
 		parser,

--- a/docker/deployed/staging/api/config.json
+++ b/docker/deployed/staging/api/config.json
@@ -8,7 +8,7 @@
   },
   "Gateway": {
     "ExternalURIPrefix": "https://staging.tableland.network",
-    "MetadataRendererURI": "https://render.tableland.xyz"
+    "MetadataRendererURI": ""
   },
   "DB": {
     "Port": "5432"

--- a/docker/deployed/staging/api/config.json
+++ b/docker/deployed/staging/api/config.json
@@ -7,7 +7,8 @@
     "TLSKey": "${VALIDATOR_TLS_KEY}"
   },
   "Gateway": {
-    "ExternalURIPrefix": "https://staging.tableland.network"
+    "ExternalURIPrefix": "https://staging.tableland.network",
+    "MetadataRendererURI": "https://render.tableland.xyz"
   },
   "DB": {
     "Port": "5432"

--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -8,7 +8,8 @@
         "TLSKey": "${VALIDATOR_TLS_KEY}"
     },
     "Gateway": {
-        "ExternalURIPrefix": "https://testnet.tableland.network"
+        "ExternalURIPrefix": "https://testnet.tableland.network",
+        "MetadataRendererURI": "https://render.tableland.xyz"
     },
     "DB": {
         "Port": "5432"

--- a/docker/local/api/config.json
+++ b/docker/local/api/config.json
@@ -5,7 +5,7 @@
   },
   "Gateway": {
     "ExternalURIPrefix": "http://localhost:8080",
-    "MetadataRendererURI": "https://render.tableland.xyz"
+    "MetadataRendererURI": ""
   },
   "Chains": [
     {

--- a/docker/local/api/config.json
+++ b/docker/local/api/config.json
@@ -4,7 +4,8 @@
     "Debug": true
   },
   "Gateway": {
-    "ExternalURIPrefix": "http://localhost:8080"
+    "ExternalURIPrefix": "http://localhost:8080",
+    "MetadataRendererURI": "https://render.tableland.xyz"
   },
   "Chains": [
     {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -22,6 +22,7 @@ import (
 // ConfiguredRouter returns a fully configured Router that can be used as an http handler.
 func ConfiguredRouter(
 	extURLPrefix string,
+	metadataRendererURI string,
 	maxRPI uint64,
 	rateLimInterval time.Duration,
 	parser parsing.SQLValidator,
@@ -49,7 +50,7 @@ func ConfiguredRouter(
 	for chainID, stack := range chainStacks {
 		stores[chainID] = stack.Store
 	}
-	sysStore, err := systemimpl.NewSystemSQLStoreService(stores, extURLPrefix)
+	sysStore, err := systemimpl.NewSystemSQLStoreService(stores, extURLPrefix, metadataRendererURI)
 	if err != nil {
 		log.Fatal().Err(err).Msg("creating system store")
 	}

--- a/internal/system/impl/sqlstore.go
+++ b/internal/system/impl/sqlstore.go
@@ -7,11 +7,14 @@ import (
 	"net/url"
 	"strings"
 
+	logger "github.com/rs/zerolog/log"
 	"github.com/textileio/go-tableland/internal/router/middlewares"
 	"github.com/textileio/go-tableland/internal/system"
 	"github.com/textileio/go-tableland/internal/tableland"
 	"github.com/textileio/go-tableland/pkg/sqlstore"
 )
+
+var log = logger.With().Str("component", "systemsqlstore").Logger()
 
 const (
 	// SystemTablesPrefix is the prefix used in table names that
@@ -150,6 +153,7 @@ func (s *SystemSQLStoreService) getMetadataImage(chainID tableland.ChainID, tabl
 
 	uri := strings.TrimRight(s.metadataRendererURI, "/")
 	if _, err := url.ParseRequestURI(uri); err != nil {
+		log.Warn().Str("uri", uri).Msg("metadata renderer uri could not be parsed")
 		return DefaultMetadataImage
 	}
 

--- a/internal/system/impl/sqlstore.go
+++ b/internal/system/impl/sqlstore.go
@@ -24,21 +24,24 @@ const (
 
 // SystemSQLStoreService implements the SystemService interface using SQLStore.
 type SystemSQLStoreService struct {
-	extURLPrefix string
-	stores       map[tableland.ChainID]sqlstore.SystemStore
+	extURLPrefix        string
+	metadataRendererURI string
+	stores              map[tableland.ChainID]sqlstore.SystemStore
 }
 
 // NewSystemSQLStoreService creates a new SystemSQLStoreService.
 func NewSystemSQLStoreService(
 	stores map[tableland.ChainID]sqlstore.SystemStore,
 	extURLPrefix string,
+	metadataRendererURI string,
 ) (system.SystemService, error) {
 	if _, err := url.ParseRequestURI(extURLPrefix); err != nil {
 		return nil, fmt.Errorf("invalid external url prefix: %s", err)
 	}
 	return &SystemSQLStoreService{
-		extURLPrefix: extURLPrefix,
-		stores:       stores,
+		extURLPrefix:        extURLPrefix,
+		metadataRendererURI: metadataRendererURI,
+		stores:              stores,
 	}, nil
 }
 
@@ -64,7 +67,7 @@ func (s *SystemSQLStoreService) GetTableMetadata(
 	return sqlstore.TableMetadata{
 		Name:        fmt.Sprintf("%s_%d_%s", table.Prefix, table.ChainID, table.ID),
 		ExternalURL: fmt.Sprintf("%s/chain/%d/tables/%s", s.extURLPrefix, table.ChainID, table.ID),
-		Image:       "https://bafkreifhuhrjhzbj4onqgbrmhpysk2mop2jimvdvfut6taiyzt2yqzt43a.ipfs.dweb.link", //nolint
+		Image:       fmt.Sprintf("%s/%d/%s", s.metadataRendererURI, table.ChainID, table.ID), //nolint
 		Attributes: []sqlstore.TableMetadataAttribute{
 			{
 				DisplayType: "date",

--- a/internal/system/impl/sqlstore_test.go
+++ b/internal/system/impl/sqlstore_test.go
@@ -149,3 +149,90 @@ func TestGetSchemaByTableName(t *testing.T) {
 
 	require.Equal(t, "CHECK(a > 0)", schema.TableConstraints[0])
 }
+
+func TestGetMetadata(t *testing.T) {
+	t.Parallel()
+
+	dbURI := tests.Sqlite3URI()
+
+	ctx := context.WithValue(context.Background(), middlewares.ContextKeyChainID, tableland.ChainID(1337))
+	store, err := system.New(dbURI, chainID)
+	require.NoError(t, err)
+
+	parser, err := parserimpl.New([]string{"system_", "registry"})
+	require.NoError(t, err)
+	// populate the registry with a table
+	ex, err := executor.NewExecutor(1337, dbURI, parser, 0, nil)
+	require.NoError(t, err)
+	bs, err := ex.NewBlockScope(ctx, 0)
+	require.NoError(t, err)
+
+	id, _ := tableland.NewTableID("42")
+	require.NoError(t, err)
+
+	res, err := bs.ExecuteTxnEvents(ctx, eventfeed.TxnEvents{
+		TxnHash: common.HexToHash("0x0"),
+		Events: []interface{}{
+			&ethereum.ContractCreateTable{
+				TableId:   big.NewInt(42),
+				Owner:     common.HexToAddress("0xb451cee4A42A652Fe77d373BAe66D42fd6B8D8FF"),
+				Statement: "create table foo_1337 (bar int)",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Nil(t, res.Error)
+	require.Nil(t, res.ErrorEventIdx)
+	require.NoError(t, bs.Commit())
+	require.NoError(t, bs.Close())
+
+	stack := map[tableland.ChainID]sqlstore.SystemStore{1337: store}
+
+	t.Run("empty metadata uri", func(t *testing.T) {
+		t.Parallel()
+
+		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "")
+		require.NoError(t, err)
+
+		metadata, err := svc.GetTableMetadata(ctx, id)
+		require.NoError(t, err)
+
+		require.Equal(t, "foo_1337_42", metadata.Name)
+		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
+		require.Equal(t, DefaultMetadataImage, metadata.Image)
+		require.Equal(t, "date", metadata.Attributes[0].DisplayType)
+		require.Equal(t, "created", metadata.Attributes[0].TraitType)
+	})
+
+	t.Run("with metadata uri", func(t *testing.T) {
+		t.Parallel()
+
+		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "https://render.tableland.xyz")
+		require.NoError(t, err)
+
+		metadata, err := svc.GetTableMetadata(ctx, id)
+		require.NoError(t, err)
+
+		require.Equal(t, "foo_1337_42", metadata.Name)
+		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
+		require.Equal(t, "https://render.tableland.xyz/1337/42", metadata.Image)
+		require.Equal(t, "date", metadata.Attributes[0].DisplayType)
+		require.Equal(t, "created", metadata.Attributes[0].TraitType)
+	})
+
+	t.Run("with metadata uri trailing slash", func(t *testing.T) {
+		t.Parallel()
+
+		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "https://render.tableland.xyz/")
+		require.NoError(t, err)
+
+		metadata, err := svc.GetTableMetadata(ctx, id)
+		require.NoError(t, err)
+
+		require.Equal(t, "foo_1337_42", metadata.Name)
+		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
+		require.Equal(t, "https://render.tableland.xyz/1337/42", metadata.Image)
+		require.Equal(t, "date", metadata.Attributes[0].DisplayType)
+		require.Equal(t, "created", metadata.Attributes[0].TraitType)
+	})
+}

--- a/internal/system/impl/sqlstore_test.go
+++ b/internal/system/impl/sqlstore_test.go
@@ -59,14 +59,14 @@ func TestSystemSQLStoreService(t *testing.T) {
 	require.NoError(t, bs.Close())
 
 	stack := map[tableland.ChainID]sqlstore.SystemStore{1337: store}
-	svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables")
+	svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "https://render.tableland.xyz")
 	require.NoError(t, err)
 	metadata, err := svc.GetTableMetadata(ctx, id)
 	require.NoError(t, err)
 
 	require.Equal(t, "foo_1337_42", metadata.Name)
 	require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
-	require.Equal(t, "https://bafkreifhuhrjhzbj4onqgbrmhpysk2mop2jimvdvfut6taiyzt2yqzt43a.ipfs.dweb.link", metadata.Image) //nolint
+	require.Equal(t, "https://render.tableland.xyz/1337/42", metadata.Image) //nolint
 	require.Equal(t, "date", metadata.Attributes[0].DisplayType)
 	require.Equal(t, "created", metadata.Attributes[0].TraitType)
 
@@ -127,7 +127,7 @@ func TestGetSchemaByTableName(t *testing.T) {
 	require.NoError(t, bs.Close())
 
 	stack := map[tableland.ChainID]sqlstore.SystemStore{1337: store}
-	svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables")
+	svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "https://render.tableland.xyz")
 	require.NoError(t, err)
 
 	schema, err := svc.GetSchemaByTableName(ctx, "foo_1337_42")

--- a/internal/system/impl/sqlstore_test.go
+++ b/internal/system/impl/sqlstore_test.go
@@ -235,4 +235,20 @@ func TestGetMetadata(t *testing.T) {
 		require.Equal(t, "date", metadata.Attributes[0].DisplayType)
 		require.Equal(t, "created", metadata.Attributes[0].TraitType)
 	})
+
+	t.Run("with wrong metadata uri", func(t *testing.T) {
+		t.Parallel()
+
+		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "foo")
+		require.NoError(t, err)
+
+		metadata, err := svc.GetTableMetadata(ctx, id)
+		require.NoError(t, err)
+
+		require.Equal(t, "foo_1337_42", metadata.Name)
+		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
+		require.Equal(t, DefaultMetadataImage, metadata.Image)
+		require.Equal(t, "date", metadata.Attributes[0].DisplayType)
+		require.Equal(t, "created", metadata.Attributes[0].TraitType)
+	})
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -178,6 +178,7 @@ func setup(t *testing.T) clientCalls {
 
 	router := router.ConfiguredRouter(
 		"https://testnet.tableland.network",
+		"https://render.tableland.xyz",
 		10,
 		time.Second,
 		parser,


### PR DESCRIPTION
Adds a config for the table metadata renderer: `https://render.tableland.xyz`

cc @awmuncy 