### PR TITLE
Adds SVG rendering when metadata call can't find the table

### DIFF
--- a/internal/system/impl/sqlstore.go
+++ b/internal/system/impl/sqlstore.go
@@ -66,12 +66,21 @@ func (s *SystemSQLStoreService) GetTableMetadata(
 	}
 	store, ok := s.stores[chainID]
 	if !ok {
-		return sqlstore.TableMetadata{}, fmt.Errorf("chain id %d isn't supported in the validator", chainID)
+		return sqlstore.TableMetadata{
+			ExternalURL: fmt.Sprintf("%s/chain/%d/tables/%s", s.extURLPrefix, chainID, id),
+			Image:       s.emptyMetadataImage(),
+			Message:     "Chain isn't supported",
+		}, nil
 	}
 	table, err := store.GetTable(ctx, id)
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
-			return sqlstore.TableMetadata{}, fmt.Errorf("error fetching the table: %s", err)
+			log.Error().Err(err).Msg("error fetching the table")
+			return sqlstore.TableMetadata{
+				ExternalURL: fmt.Sprintf("%s/chain/%d/tables/%s", s.extURLPrefix, chainID, id),
+				Image:       s.emptyMetadataImage(),
+				Message:     "Failed to fetch the table",
+			}, nil
 		}
 
 		return sqlstore.TableMetadata{

--- a/internal/system/impl/sqlstore_test.go
+++ b/internal/system/impl/sqlstore_test.go
@@ -251,4 +251,21 @@ func TestGetMetadata(t *testing.T) {
 		require.Equal(t, "date", metadata.Attributes[0].DisplayType)
 		require.Equal(t, "created", metadata.Attributes[0].TraitType)
 	})
+
+	t.Run("non existent table", func(t *testing.T) {
+		t.Parallel()
+
+		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "foo")
+		require.NoError(t, err)
+
+		id, _ := tableland.NewTableID("43")
+		require.NoError(t, err)
+
+		metadata, err := svc.GetTableMetadata(ctx, id)
+		require.NoError(t, err)
+
+		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
+		require.Equal(t, "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nNTEyJyBoZWlnaHQ9JzUxMicgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJz48cmVjdCB3aWR0aD0nNTEyJyBoZWlnaHQ9JzUxMicgZmlsbD0nIzAwMCcvPjwvc3ZnPg==", metadata.Image) // nolint
+		require.Equal(t, "Table not found", metadata.Message)
+	})
 }

--- a/pkg/sqlstore/impl/system/store.go
+++ b/pkg/sqlstore/impl/system/store.go
@@ -71,7 +71,7 @@ func (s *SystemStore) GetTable(ctx context.Context, id tableland.TableID) (sqlst
 		ID:      id.ToBigInt().Int64(),
 	})
 	if err != nil {
-		return sqlstore.Table{}, fmt.Errorf("failed to get the table: %s", err)
+		return sqlstore.Table{}, fmt.Errorf("failed to get the table: %w", err)
 	}
 	return tableFromSQLToDTO(table)
 }

--- a/pkg/sqlstore/table.go
+++ b/pkg/sqlstore/table.go
@@ -37,10 +37,11 @@ type ColumnSchema struct {
 
 // TableMetadata represents table metadata (OpenSea standard).
 type TableMetadata struct {
-	Name        string                   `json:"name"`
+	Name        string                   `json:"name,omitempty"`
 	ExternalURL string                   `json:"external_url"`
 	Image       string                   `json:"image"`
-	Attributes  []TableMetadataAttribute `json:"attributes"`
+	Message     string                   `json:"message,omitempty"`
+	Attributes  []TableMetadataAttribute `json:"attributes,omitempty"`
 }
 
 // TableMetadataAttribute represents the table metadata attribute.


### PR DESCRIPTION
This PR updates the response for getting metadata in the `GET /chain/{chain_id}/tables/{table_id}` call.

Instead of returning an error, such as `"Failed to fetch metadata"` we return a response that complies to that NFT metadata standard and also an SVG to represent that visually. 

Examples: 
- Invalid chain: https://staging.tableland.network/chain/45/tables/30
- Table not found: https://staging.tableland.network/chain/69/tables/30

cc @andrewxhill 