### PR TITLE
Add support for networks, direct write queries, validate

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/textileio/go-tableland/internal/tableland"
 	"github.com/textileio/go-tableland/pkg/nonce/impl"
@@ -19,22 +20,7 @@ import (
 	"github.com/textileio/go-tableland/pkg/wallet"
 )
 
-// Client is the Tableland client.
-type Client struct {
-	tblRPC      *rpc.Client
-	tblHTTP     *http.Client
-	tblContract *ethereum.Client
-	config      Config
-}
-
-// Config configures the Client.
-type Config struct {
-	TblAPIURL    string
-	EthBackend   bind.ContractBackend
-	ChainID      ChainID
-	ContractAddr common.Address
-	Wallet       *wallet.Wallet
-}
+var defaultNetwork = TestnetPolygonMumbai
 
 // TxnReceipt is a Tableland event processing receipt.
 type TxnReceipt struct {
@@ -63,9 +49,6 @@ func (tid TableID) ToBigInt() *big.Int {
 	return b
 }
 
-// ChainID is a supported EVM chain identifier.
-type ChainID int64
-
 // TableInfo summarizes information about a table.
 type TableInfo struct {
 	Controller string    `json:"controller"`
@@ -86,25 +69,108 @@ func NewTableID(strID string) (TableID, error) {
 	return TableID(*tableID), nil
 }
 
+// Client is the Tableland client.
+type Client struct {
+	tblRPC      *rpc.Client
+	tblHTTP     *http.Client
+	tblContract *ethereum.Client
+	networkInfo NetworkInfo
+	relayWrites bool
+	wallet      *wallet.Wallet
+}
+
+type config struct {
+	networkInfo     *NetworkInfo
+	relayWrites     *bool
+	infuraAPIKey    string
+	alchemyAPIKey   string
+	local           bool
+	contractBackend bind.ContractBackend
+}
+
+// NewClientOption controls the behavior of NewClient.
+type NewClientOption func(*config)
+
+// NewClientNetworkInfo specifies network info.
+func NewClientNetworkInfo(networkInfo NetworkInfo) NewClientOption {
+	return func(ncc *config) {
+		ncc.networkInfo = &networkInfo
+	}
+}
+
+// NewClientRelayWrites specifies whether or not to relay write queries through the Tableland validator.
+func NewClientRelayWrites(relay bool) NewClientOption {
+	return func(ncc *config) {
+		ncc.relayWrites = &relay
+	}
+}
+
+// NewClientInfuraAPIKey specifies an Infura API to use when creating an EVM backend.
+func NewClientInfuraAPIKey(key string) NewClientOption {
+	return func(c *config) {
+		c.infuraAPIKey = key
+	}
+}
+
+// NewClientAlchemyAPIKey specifies an Alchemy API to use when creating an EVM backend.
+func NewClientAlchemyAPIKey(key string) NewClientOption {
+	return func(c *config) {
+		c.alchemyAPIKey = key
+	}
+}
+
+// NewClientLocal specifies that a local EVM backend should be used.
+func NewClientLocal() NewClientOption {
+	return func(c *config) {
+		c.local = true
+	}
+}
+
+// NewClientContractBackend specifies a custom EVM backend to use.
+func NewClientContractBackend(backend bind.ContractBackend) NewClientOption {
+	return func(c *config) {
+		c.contractBackend = backend
+	}
+}
+
 // NewClient creates a new Client.
-func NewClient(ctx context.Context, config Config) (*Client, error) {
+func NewClient(ctx context.Context, wallet *wallet.Wallet, opts ...NewClientOption) (*Client, error) {
+	config := config{networkInfo: &defaultNetwork}
+	for _, opt := range opts {
+		opt(&config)
+	}
+	var relay bool
+	if config.relayWrites != nil {
+		relay = *config.relayWrites
+	} else {
+		relay = config.networkInfo.CanRelayWrites()
+	}
+	if relay && !config.networkInfo.CanRelayWrites() {
+		return nil, errors.New("options specified to relay writes for a network that doesn't support it")
+	}
+
+	contractBackend, err := getContractBackend(ctx, config)
+	if err != nil {
+		return nil, fmt.Errorf("getting contract backend: %v", err)
+	}
+
 	tblContract, err := ethereum.NewClient(
-		config.EthBackend,
-		tableland.ChainID(config.ChainID),
-		config.ContractAddr,
-		config.Wallet,
-		impl.NewSimpleTracker(config.Wallet, config.EthBackend),
+		contractBackend,
+		tableland.ChainID(config.networkInfo.ChainID),
+		config.networkInfo.ContractAddr,
+		wallet,
+		impl.NewSimpleTracker(wallet, contractBackend),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating contract client: %v", err)
 	}
 
-	siwe, err := siwe.EncodedSIWEMsg(tableland.ChainID(config.ChainID), config.Wallet, time.Hour*24*365)
+	siwe, err := siwe.EncodedSIWEMsg(tableland.ChainID(config.networkInfo.ChainID), wallet, time.Hour*24*365)
 	if err != nil {
 		return nil, fmt.Errorf("creating siwe value: %v", err)
 	}
 
-	tblRPC, err := rpc.DialContext(ctx, config.TblAPIURL+"/rpc")
+	tblRPC, err := rpc.DialContext(ctx, string(config.networkInfo.Network)+"/rpc")
 	if err != nil {
 		return nil, fmt.Errorf("creating rpc client: %v", err)
 	}
@@ -114,7 +180,9 @@ func NewClient(ctx context.Context, config Config) (*Client, error) {
 		tblRPC:      tblRPC,
 		tblHTTP:     &http.Client{},
 		tblContract: tblContract,
-		config:      config,
+		networkInfo: *config.networkInfo,
+		relayWrites: relay,
+		wallet:      wallet,
 	}, nil
 }
 
@@ -122,9 +190,9 @@ func NewClient(ctx context.Context, config Config) (*Client, error) {
 func (c *Client) List(ctx context.Context) ([]TableInfo, error) {
 	url := fmt.Sprintf(
 		"%s/chain/%d/tables/controller/%s",
-		c.config.TblAPIURL,
-		c.config.ChainID,
-		c.config.Wallet.Address().Hex(),
+		c.networkInfo.Network,
+		c.networkInfo.ChainID,
+		c.wallet.Address().Hex(),
 	)
 	res, err := c.tblHTTP.Get(url)
 	if err != nil {
@@ -175,7 +243,7 @@ func (c *Client) Create(ctx context.Context, schema string, opts ...CreateOption
 		opt(&conf)
 	}
 
-	createStatement := fmt.Sprintf("CREATE TABLE %s_%d %s", conf.prefix, c.config.ChainID, schema)
+	createStatement := fmt.Sprintf("CREATE TABLE %s_%d %s", conf.prefix, c.networkInfo.ChainID, schema)
 	req := &tableland.ValidateCreateTableRequest{CreateStatement: createStatement}
 	var res tableland.ValidateCreateTableResponse
 
@@ -183,7 +251,7 @@ func (c *Client) Create(ctx context.Context, schema string, opts ...CreateOption
 		return TableID{}, "", fmt.Errorf("calling rpc validateCreateTable: %v", err)
 	}
 
-	t, err := c.tblContract.CreateTable(ctx, c.config.Wallet.Address(), createStatement)
+	t, err := c.tblContract.CreateTable(ctx, c.wallet.Address(), createStatement)
 	if err != nil {
 		return TableID{}, "", fmt.Errorf("calling contract create table: %v", err)
 	}
@@ -201,7 +269,7 @@ func (c *Client) Create(ctx context.Context, schema string, opts ...CreateOption
 		return TableID{}, "", errors.New("parsing table id from response")
 	}
 
-	return TableID(*tableID), fmt.Sprintf("%s_%d_%s", conf.prefix, c.config.ChainID, *r.TableID), nil
+	return TableID(*tableID), fmt.Sprintf("%s_%d_%s", conf.prefix, c.networkInfo.ChainID, *r.TableID), nil
 }
 
 // Read runs a read query and returns the results.
@@ -222,28 +290,69 @@ func (c *Client) Read(ctx context.Context, query string) (string, error) {
 	return string(b), nil
 }
 
-// Write initiates a write query, returning the txn hash.
-func (c *Client) Write(ctx context.Context, query string) (string, error) {
-	req := &tableland.RelayWriteQueryRequest{Statement: query}
-	var res tableland.RelayWriteQueryResponse
+type writeConfig struct {
+	relay bool
+}
 
-	if err := c.tblRPC.CallContext(ctx, &res, "tableland_relayWriteQuery", req); err != nil {
-		return "", fmt.Errorf("calling rpc relayWriteQuery: %v", err)
+// WriteOption controls the behavior of Write.
+type WriteOption func(*writeConfig)
+
+// WriteRelay specifies whether or not to relay write queries through the Tableland validator.
+// Default behavior is false for main net EVM chains, true for all others.
+func WriteRelay(relay bool) WriteOption {
+	return func(wc *writeConfig) {
+		wc.relay = relay
 	}
+}
 
-	return res.Transaction.Hash, nil
+// Write initiates a write query, returning the txn hash.
+func (c *Client) Write(ctx context.Context, query string, opts ...WriteOption) (string, error) {
+	conf := writeConfig{relay: c.relayWrites}
+	for _, opt := range opts {
+		opt(&conf)
+	}
+	if conf.relay {
+		req := &tableland.RelayWriteQueryRequest{Statement: query}
+		var res tableland.RelayWriteQueryResponse
+		if err := c.tblRPC.CallContext(ctx, &res, "tableland_relayWriteQuery", req); err != nil {
+			return "", fmt.Errorf("calling rpc relayWriteQuery: %v", err)
+		}
+		return res.Transaction.Hash, nil
+	}
+	tableID, err := c.Validate(ctx, query)
+	if err != nil {
+		return "", fmt.Errorf("calling Validate: %v", err)
+	}
+	res, err := c.tblContract.RunSQL(ctx, c.wallet.Address(), tableland.TableID(tableID), query)
+	if err != nil {
+		return "", fmt.Errorf("calling RunSQL: %v", err)
+	}
+	return res.Hash().Hex(), nil
 }
 
 // Hash validates the provided create table statement and returns its hash.
 func (c *Client) Hash(ctx context.Context, statement string) (string, error) {
 	req := &tableland.ValidateCreateTableRequest{CreateStatement: statement}
 	var res tableland.ValidateCreateTableResponse
-
 	if err := c.tblRPC.CallContext(ctx, &res, "tableland_validateCreateTable", req); err != nil {
 		return "", fmt.Errorf("calling rpc validateCreateTable: %v", err)
 	}
-
 	return res.StructureHash, nil
+}
+
+// Validate validates a write query, returning the table id.
+func (c *Client) Validate(ctx context.Context, statement string) (TableID, error) {
+	req := &tableland.ValidateWriteQueryRequest{Statement: statement}
+	var res tableland.ValidateWriteQueryResponse
+	if err := c.tblRPC.CallContext(ctx, &res, "tableland_validateWriteQuery", req); err != nil {
+		return TableID{}, fmt.Errorf("calling rpc validateWriteQuery: %v", err)
+	}
+	tableID, ok := big.NewInt(0).SetString(res.TableID, 10)
+	if !ok {
+		return TableID{}, errors.New("parsing table id from response")
+	}
+
+	return TableID(*tableID), nil
 }
 
 type receiptConfig struct {
@@ -339,4 +448,29 @@ func (c *Client) waitForReceipt(
 // Close implements Close.
 func (c *Client) Close() {
 	c.tblRPC.Close()
+}
+
+func getContractBackend(ctx context.Context, config config) (bind.ContractBackend, error) {
+	if config.contractBackend != nil && config.infuraAPIKey == "" && config.alchemyAPIKey == "" {
+		return config.contractBackend, nil
+	} else if config.infuraAPIKey != "" && config.contractBackend == nil && config.alchemyAPIKey == "" {
+		tmpl, found := infuraURLs[config.networkInfo.ChainID]
+		if !found {
+			return nil, fmt.Errorf("chain id %v not supported for Infura", config.networkInfo.ChainID)
+		}
+		return ethclient.DialContext(ctx, fmt.Sprintf(tmpl, config.infuraAPIKey))
+	} else if config.alchemyAPIKey != "" && config.contractBackend == nil && config.infuraAPIKey == "" {
+		tmpl, found := alchemyURLs[config.networkInfo.ChainID]
+		if !found {
+			return nil, fmt.Errorf("chain id %v not supported for Alchemy", config.networkInfo.ChainID)
+		}
+		return ethclient.DialContext(ctx, fmt.Sprintf(tmpl, config.alchemyAPIKey))
+	} else if config.local {
+		url, found := localURLs[config.networkInfo.ChainID]
+		if !found {
+			return nil, fmt.Errorf("chain id %v not supported for Local", config.networkInfo.ChainID)
+		}
+		return ethclient.DialContext(ctx, url)
+	}
+	return nil, errors.New("no provider specified, must provide an Infura API key, Alchemy API key, or an ETH backend")
 }

--- a/pkg/client/networks.go
+++ b/pkg/client/networks.go
@@ -1,0 +1,163 @@
+package client
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Network represents a Tableland network.
+type Network string
+
+const (
+	// Testnet is the Tableland testnet network.
+	Testnet Network = "https://testnet.tableland.network"
+	// Staging is the Tableland staging network.
+	Staging Network = "https://staging.tableland.network"
+	// Localhost is the Tableland local network.
+	Localhost Network = "http://localhost:8080"
+)
+
+// ChainID is a supported EVM chain identifier.
+type ChainID int64
+
+const (
+	// EthereumGoerli is the Ethereum Goerli chain id.
+	EthereumGoerli ChainID = 5
+	// Ethereum is the Ethereum chain id.
+	Ethereum ChainID = 1
+	// OptimismKovan is the Optimism Kovan chains id.
+	OptimismKovan ChainID = 69
+	// OptimismGoerli is the Optimism Goerli chain id.
+	OptimismGoerli ChainID = 420
+	// Optimism is the Optmism chain id.
+	Optimism ChainID = 10
+	// ArbitrumGoerli is the Arbitrum Goerli chain id.
+	ArbitrumGoerli ChainID = 421613
+	// PolygonMumbai is the Poygon Mumbai chain id.
+	PolygonMumbai ChainID = 80001
+	// Polygon is the Polygon chiain id.
+	Polygon ChainID = 137
+	// Local is the typical local chain id.
+	Local ChainID = 31337
+)
+
+var infuraURLs = map[ChainID]string{
+	EthereumGoerli: "https://goerli.infura.io/v3/%s",
+	Ethereum:       "https://mainnet.infura.io/v3/%s",
+	OptimismKovan:  "https://optimism-kovan.infura.io/v3/%s",
+	OptimismGoerli: "https://optimism-goerli.infura.io/v3/%s",
+	Optimism:       "https://optimism-mainnet.infura.io/v3/%s",
+	ArbitrumGoerli: "https://arbitrim-goerli.infura.io/v3/%s", // TODO: Check this, requires upgrade.
+	PolygonMumbai:  "https://polygon-mumbai.infura.io/v3/%s",
+	Polygon:        "https://polygon-mainnet.infura.io/v3/%s",
+}
+
+var alchemyURLs = map[ChainID]string{
+	EthereumGoerli: "https://eth-goerli.g.alchemy.com/v2/%s",
+	Ethereum:       "https://eth-mainnet.g.alchemy.com/v2/%s",
+	OptimismKovan:  "https://opt-kovan.g.alchemy.com/v2/%s",
+	OptimismGoerli: "https://opt-goerli.g.alchemy.com/v2/%s",
+	Optimism:       "https://opt-mainnet.g.alchemy.com/v2/%s",
+	ArbitrumGoerli: "https://arb-goerli.g.alchemy.com/v2/%s",
+	PolygonMumbai:  "https://polygon-mumbai.g.alchemy.com/v2/%s",
+	Polygon:        "https://polygon-mainnet.g.alchemy.com/v2/%s",
+}
+
+var localURLs = map[ChainID]string{
+	Local: "http://localhost:8545",
+}
+
+// NetworkInfo is a info about a network supported by Talbleland.
+type NetworkInfo struct {
+	Network      Network
+	ChainID      ChainID
+	ContractAddr common.Address
+}
+
+var (
+	// Tableland testnet mainnets.
+	//--------------------------------------------------------------------------------------.
+
+	// TestnetEtherum is network: Testnet, chain: Ethereum.
+	TestnetEtherum = NetworkInfo{
+		Network:      Testnet,
+		ChainID:      Ethereum,
+		ContractAddr: common.HexToAddress("0x012969f7e3439a9B04025b5a049EB9BAD82A8C12"),
+	}
+	// TestnetOptimism is network: Testnet, chain: Optimism.
+	TestnetOptimism = NetworkInfo{
+		Network:      Testnet,
+		ChainID:      Optimism,
+		ContractAddr: common.HexToAddress("0xfad44BF5B843dE943a09D4f3E84949A11d3aa3e6"),
+	}
+	// TestnetPolygon is network: Testnet, chain: Polygon.
+	TestnetPolygon = NetworkInfo{
+		Network:      Testnet,
+		ChainID:      Polygon,
+		ContractAddr: common.HexToAddress("0x5c4e6A9e5C1e1BF445A062006faF19EA6c49aFeA"),
+	}
+
+	// Tableland testnet testnets.
+	//--------------------------------------------------------------------------------------.
+
+	// TestnetEthereumGoerli is network: Testnet, chain: EthereumGoerli.
+	TestnetEthereumGoerli = NetworkInfo{
+		Network:      Testnet,
+		ChainID:      EthereumGoerli,
+		ContractAddr: common.HexToAddress("0xDA8EA22d092307874f30A1F277D1388dca0BA97a"),
+	}
+	// TestnetOptimismKovan is network: Testnet, chain: OptimismKovan.
+	TestnetOptimismKovan = NetworkInfo{
+		Network:      Testnet,
+		ChainID:      OptimismKovan,
+		ContractAddr: common.HexToAddress("0xf2C9Fc73884A9c6e6Db58778176Ab67989139D06"),
+	}
+	// TestnetOptimismGoerli is network: Testnet, chain: OptimismGoerli.
+	TestnetOptimismGoerli = NetworkInfo{
+		Network:      Testnet,
+		ChainID:      OptimismGoerli,
+		ContractAddr: common.HexToAddress("0xC72E8a7Be04f2469f8C2dB3F1BdF69A7D516aBbA"),
+	}
+	// TestnetArbitrumGoerli is network: Testnet, chain: ArbitrumGoerli.
+	TestnetArbitrumGoerli = NetworkInfo{
+		Network:      Testnet,
+		ChainID:      ArbitrumGoerli,
+		ContractAddr: common.HexToAddress("0x033f69e8d119205089Ab15D340F5b797732f646b"),
+	}
+	// TestnetPolygonMumbai is network: Testnet, chain: PolygonMumbai.
+	TestnetPolygonMumbai = NetworkInfo{
+		Network:      Testnet,
+		ChainID:      PolygonMumbai,
+		ContractAddr: common.HexToAddress("0x4b48841d4b32C4650E4ABc117A03FE8B51f38F68"),
+	}
+
+	// Tableland staging testnets.
+	//--------------------------------------------------------------------------------------.
+
+	// StagingOptimismKovan is network: Staging, chain: OptimismKovan.
+	StagingOptimismKovan = NetworkInfo{
+		Network:      Staging,
+		ChainID:      OptimismKovan,
+		ContractAddr: common.HexToAddress("0x7E57BaA6724c7742de6843094002c4e58FF6c7c3"),
+	}
+	// StagingOptimismGoerli is network: Staging, chain: OptimismGoerli.
+	StagingOptimismGoerli = NetworkInfo{
+		Network:      Staging,
+		ChainID:      OptimismGoerli,
+		ContractAddr: common.HexToAddress("0xfe79824f6E5894a3DD86908e637B7B4AF57eEE28"),
+	}
+
+	// Local
+	//--------------------------------------------------------------------------------------.
+
+	// LocalhostLocal is network: LocalDev, chain: Local.
+	LocalhostLocal = NetworkInfo{
+		Network:      Localhost,
+		ChainID:      Local,
+		ContractAddr: common.HexToAddress("0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"),
+	}
+)
+
+// CanRelayWrites returns whether Tableland validators will relay write requests.
+func (sn NetworkInfo) CanRelayWrites() bool {
+	return sn.ChainID != Ethereum && sn.ChainID != Optimism && sn.ChainID != Polygon
+}


### PR DESCRIPTION
This provides easier client configuration using hard coded information about the networks and contract addressees available. Also adds support for non-relayed write queries and rpc calls to validate write queries.