### PR TITLE
Parser update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/spruceid/siwe-go v0.2.1-0.20220711143404-817846826282
 	github.com/stretchr/testify v1.8.0
-	github.com/tablelandnetwork/sqlparser v0.0.0-20220725134734-b79ca3e804c8
+	github.com/tablelandnetwork/sqlparser v0.0.0-20220830151425-aec4df78e4c8
 	github.com/textileio/cli v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.32.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.34.0

--- a/go.sum
+++ b/go.sum
@@ -978,7 +978,6 @@ github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOq
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.10/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v1.14.13/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.15 h1:vfoHhTN1af61xCRSWzFIWzx2YskyMTwHLrExkBOjvxI=
 github.com/mattn/go-sqlite3 v1.14.15/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
@@ -1293,8 +1292,8 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a h1:1ur3QoCqvE5fl+nylMaIr9PVV1w343YRDtsy+Rwu7XI=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
-github.com/tablelandnetwork/sqlparser v0.0.0-20220725134734-b79ca3e804c8 h1:SX7qBAHLjeD/UtGuUnkDU7Os8pMOfOKi4Bh4jvkDI+c=
-github.com/tablelandnetwork/sqlparser v0.0.0-20220725134734-b79ca3e804c8/go.mod h1:tiNXABmR9dWeLDts7u2l6onz2sH9isfctTnUOakplAU=
+github.com/tablelandnetwork/sqlparser v0.0.0-20220830151425-aec4df78e4c8 h1:4sqEmxrC4M27a4pDUhw7WFrrbD3GbFS/8iYiQ3M5hJw=
+github.com/tablelandnetwork/sqlparser v0.0.0-20220830151425-aec4df78e4c8/go.mod h1:hEWKQ1CaX9T+3GgbIkgkcLk4x2V4wuWWC1fB6Kzfthg=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/textileio/cli v1.0.2 h1:qSp/x4d/9SZ93TxhgZnE5okRKqzqHqrzAwKAPjuPw50=
 github.com/textileio/cli v1.0.2/go.mod h1:vTlCvvVyOmXXLwddCcBg3PDavfUsCkRBZoyr6Nu1lkc=

--- a/pkg/parsing/impl/validator.go
+++ b/pkg/parsing/impl/validator.go
@@ -48,7 +48,7 @@ func New(systemTablePrefixes []string, opts ...parsing.Option) (parsing.SQLValid
 func (pp *QueryValidator) ValidateCreateTable(query string, chainID tableland.ChainID) (parsing.CreateStmt, error) {
 	ast, err := sqlparser.Parse(query)
 	if err != nil {
-		return nil, &parsing.ErrInvalidSyntax{InternalError: err}
+		return nil, fmt.Errorf("unable to parse the query: %w", err)
 	}
 
 	if err := checkNonEmptyStatement(ast); err != nil {
@@ -58,10 +58,6 @@ func (pp *QueryValidator) ValidateCreateTable(query string, chainID tableland.Ch
 	stmt := ast.Statements[0]
 	if _, ok := stmt.(sqlparser.CreateTableStatement); !ok {
 		return nil, &parsing.ErrNoTopLevelCreate{}
-	}
-
-	if ast.Errors[0] != nil {
-		return nil, fmt.Errorf("non syntax error: %w", ast.Errors[0])
 	}
 
 	node := stmt.(*sqlparser.CreateTable)
@@ -110,7 +106,7 @@ func (pp *QueryValidator) ValidateMutatingQuery(
 
 	ast, err := sqlparser.Parse(query)
 	if err != nil {
-		return nil, &parsing.ErrInvalidSyntax{InternalError: err}
+		return nil, fmt.Errorf("unable to parse the query: %w", err)
 	}
 
 	if err := checkNonEmptyStatement(ast); err != nil {
@@ -210,7 +206,7 @@ func (pp *QueryValidator) ValidateReadQuery(query string) (parsing.ReadStmt, err
 
 	ast, err := sqlparser.Parse(query)
 	if err != nil {
-		return nil, &parsing.ErrInvalidSyntax{InternalError: err}
+		return nil, fmt.Errorf("unable to parse the query: %w", err)
 	}
 
 	if err := checkNonEmptyStatement(ast); err != nil {
@@ -219,10 +215,6 @@ func (pp *QueryValidator) ValidateReadQuery(query string) (parsing.ReadStmt, err
 
 	if _, ok := ast.Statements[0].(*sqlparser.Select); !ok {
 		return nil, errors.New("the query isn't a read-query")
-	}
-
-	if ast.Errors[0] != nil {
-		return nil, fmt.Errorf("non syntax error: %w", ast.Errors[0])
 	}
 
 	return &readStmt{

--- a/pkg/parsing/impl/validator_test.go
+++ b/pkg/parsing/impl/validator_test.go
@@ -896,8 +896,8 @@ func newParser(t *testing.T, prefixes []string, opts ...parsing.Option) parsing.
 }
 
 // Helpers to have a pointer to pointer for generic test-case running.
-func ptr2ErrInvalidSyntax() **parsing.ErrInvalidSyntax {
-	var e *parsing.ErrInvalidSyntax
+func ptr2ErrInvalidSyntax() **sqlparser.ErrSyntaxError {
+	var e *sqlparser.ErrSyntaxError
 	return &e
 }
 

--- a/pkg/parsing/query_validator.go
+++ b/pkg/parsing/query_validator.go
@@ -108,16 +108,6 @@ var (
 	ErrCanOnlyCheckColumnsOnUPDATE = errors.New("can only check columns on update")
 )
 
-// ErrInvalidSyntax is an error returned when parsing the query.
-// The InternalError attribute has the underlying parser error when parsing the query.
-type ErrInvalidSyntax struct {
-	InternalError error
-}
-
-func (e *ErrInvalidSyntax) Error() string {
-	return fmt.Sprintf("unable to parse the query: %s", e.InternalError)
-}
-
 // ErrEmptyStatement is an error returned when the statement is empty.
 type ErrEmptyStatement struct{}
 


### PR DESCRIPTION
Updates SQL parser to the most recent version which enforces the following rule from [SQL spec ](https://docs.tableland.xyz/sql-specification#9e191076e01b4ac5a24d684060b9dc49)in the parser: Each table in Tableland may have at most one PRIMARY KEY.

The error behavior of the parser changed a bit as explained in the [PR](https://github.com/tablelandnetwork/go-sqlparser/pull/11). So, there are some changes in this PR to reflect the change in that behavior.