### PR TITLE
gha: bump Go version used for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, v1.18.x]
+        go-version: [1.18.x, v1.19.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Bump the version to the latest two releases for the GH action that runs the tests.
In particular, testing for Go 1.19 is important now that we use it for Dockerfiles.