### PR TITLE
Update golangci-lint version, revive config, fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,36 @@
 linters-settings:
+  revive:
+    ignore-generated-header: false
+    severity: warning
+    confidence: 0.8
+    errorCode: 0
+    warningCode: 0
+    rules:
+      - name:  blank-imports
+      - name:  context-as-argument
+      - name:  context-keys-type
+      - name:  dot-imports
+      - name:  error-return
+      - name:  error-strings
+      - name:  error-naming
+      - name:  exported
+      - name:  if-return
+      - name:  increment-decrement
+      - name:  var-naming
+      - name:  var-declaration
+      - name:  package-comments
+        disabled: true
+      - name:  range
+      - name:  receiver-naming
+      - name:  time-naming
+      - name:  unexported-return
+      - name:  indent-error-flow
+      - name:  errorf
+      - name:  empty-block
+      - name:  superfluous-else
+      - name:  unused-parameter
+      - name:  unreachable-code
+      - name:  redefines-builtin-id
   misspell:
     locale: US
 

--- a/Makefile
+++ b/Makefile
@@ -62,5 +62,5 @@ test:
 # Lint
 
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2 run
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0 run
 .PHONYY: lint

--- a/internal/router/controllers/infra.go
+++ b/internal/router/controllers/infra.go
@@ -16,7 +16,7 @@ func NewInfraController() *InfraController {
 }
 
 // Version returns git information of the running binary.
-func (c *InfraController) Version(rw http.ResponseWriter, r *http.Request) {
+func (c *InfraController) Version(rw http.ResponseWriter, _ *http.Request) {
 	rw.Header().Set("Content-type", "application/json")
 	summary := buildinfo.GetSummary()
 	rw.WriteHeader(http.StatusOK)

--- a/internal/router/controllers/user_test.go
+++ b/internal/router/controllers/user_test.go
@@ -153,8 +153,8 @@ type runnerMock struct {
 }
 
 func (rm *runnerMock) RunReadQuery(
-	ctx context.Context,
-	statement string,
+	_ context.Context,
+	_ string,
 ) (interface{}, error) {
 	if rm.counter == 0 {
 		rm.counter++
@@ -201,8 +201,8 @@ func (rm *runnerMock) RunReadQuery(
 type badRequestRunnerMock struct{}
 
 func (*badRequestRunnerMock) RunReadQuery(
-	ctx context.Context,
-	statement string,
+	_ context.Context,
+	_ string,
 ) (interface{}, error) {
 	return "bad result", nil
 }
@@ -210,8 +210,8 @@ func (*badRequestRunnerMock) RunReadQuery(
 type notFoundRunnerMock struct{}
 
 func (*notFoundRunnerMock) RunReadQuery(
-	ctx context.Context,
-	statement string,
+	_ context.Context,
+	_ string,
 ) (interface{}, error) {
 	return &sqlstore.UserRows{
 		Columns: []sqlstore.UserColumn{
@@ -236,8 +236,8 @@ func (*notFoundRunnerMock) RunReadQuery(
 type queryRunnerMock struct{}
 
 func (rm *queryRunnerMock) RunReadQuery(
-	ctx context.Context,
-	statement string,
+	_ context.Context,
+	_ string,
 ) (interface{}, error) {
 	return &sqlstore.UserRows{
 		Columns: []sqlstore.UserColumn{

--- a/internal/router/middlewares/ratelim_test.go
+++ b/internal/router/middlewares/ratelim_test.go
@@ -260,5 +260,5 @@ func TestRateLim10IPs(t *testing.T) {
 
 type dummyHandler struct{}
 
-func (dh dummyHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+func (dh dummyHandler) ServeHTTP(_ http.ResponseWriter, _ *http.Request) {
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -101,7 +101,7 @@ func ConfiguredRouter(
 	return router
 }
 
-func healthHandler(w http.ResponseWriter, r *http.Request) {
+func healthHandler(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/internal/system/impl/mock.go
+++ b/internal/system/impl/mock.go
@@ -21,7 +21,7 @@ func NewSystemMockService() system.SystemService {
 }
 
 // GetTableMetadata returns a fixed value for testing and demo purposes.
-func (*SystemMockService) GetTableMetadata(ctx context.Context, id tables.TableID) (sqlstore.TableMetadata, error) {
+func (*SystemMockService) GetTableMetadata(_ context.Context, id tables.TableID) (sqlstore.TableMetadata, error) {
 	return sqlstore.TableMetadata{
 		Name:        "name-1",
 		ExternalURL: fmt.Sprintf("https://tableland.network/tables/%s", id),
@@ -37,7 +37,7 @@ func (*SystemMockService) GetTableMetadata(ctx context.Context, id tables.TableI
 }
 
 // GetTablesByController returns table's fetched from SQLStore by controller address.
-func (s *SystemMockService) GetTablesByController(ctx context.Context, controller string) ([]sqlstore.Table, error) {
+func (s *SystemMockService) GetTablesByController(_ context.Context, _ string) ([]sqlstore.Table, error) {
 	return []sqlstore.Table{
 		{
 			ID:         tables.TableID(*big.NewInt(0)),
@@ -59,7 +59,7 @@ func (s *SystemMockService) GetTablesByController(ctx context.Context, controlle
 }
 
 // GetTablesByStructure returns all tables that share the same structure.
-func (s *SystemMockService) GetTablesByStructure(ctx context.Context, structure string) ([]sqlstore.Table, error) {
+func (s *SystemMockService) GetTablesByStructure(_ context.Context, _ string) ([]sqlstore.Table, error) {
 	return []sqlstore.Table{
 		{
 			ID:         tables.TableID(*big.NewInt(0)),
@@ -81,7 +81,7 @@ func (s *SystemMockService) GetTablesByStructure(ctx context.Context, structure 
 }
 
 // GetSchemaByTableName returns the schema of a table by its name.
-func (s *SystemMockService) GetSchemaByTableName(ctx context.Context, name string) (sqlstore.TableSchema, error) {
+func (s *SystemMockService) GetSchemaByTableName(_ context.Context, _ string) (sqlstore.TableSchema, error) {
 	return sqlstore.TableSchema{
 		Columns: []sqlstore.ColumnSchema{
 			{
@@ -111,23 +111,23 @@ func NewSystemMockErrService() system.SystemService {
 
 // GetTableMetadata returns a fixed value for testing and demo purposes.
 func (*SystemMockErrService) GetTableMetadata(
-	ctx context.Context,
-	id tables.TableID,
+	_ context.Context,
+	_ tables.TableID,
 ) (sqlstore.TableMetadata, error) {
 	return sqlstore.TableMetadata{}, errors.New("table not found")
 }
 
 // GetTablesByController returns table's fetched from SQLStore by controller address.
-func (s *SystemMockErrService) GetTablesByController(ctx context.Context, controller string) ([]sqlstore.Table, error) {
+func (s *SystemMockErrService) GetTablesByController(_ context.Context, _ string) ([]sqlstore.Table, error) {
 	return []sqlstore.Table{}, errors.New("no table found")
 }
 
 // GetTablesByStructure returns all tables that share the same structure.
-func (s *SystemMockErrService) GetTablesByStructure(ctx context.Context, structure string) ([]sqlstore.Table, error) {
+func (s *SystemMockErrService) GetTablesByStructure(_ context.Context, _ string) ([]sqlstore.Table, error) {
 	return []sqlstore.Table{}, errors.New("no table found")
 }
 
 // GetSchemaByTableName returns the schema of a table by its name.
-func (s *SystemMockErrService) GetSchemaByTableName(ctx context.Context, name string) (sqlstore.TableSchema, error) {
+func (s *SystemMockErrService) GetSchemaByTableName(_ context.Context, _ string) (sqlstore.TableSchema, error) {
 	return sqlstore.TableSchema{}, errors.New("no table found")
 }

--- a/internal/tableland/impl/mesa.go
+++ b/internal/tableland/impl/mesa.go
@@ -35,7 +35,7 @@ func NewTablelandMesa(
 // ValidateCreateTable allows to validate a CREATE TABLE statement and also return the structure hash of it.
 // This RPC method is stateless.
 func (t *TablelandMesa) ValidateCreateTable(
-	ctx context.Context,
+	_ context.Context,
 	chainID tableland.ChainID,
 	statement string,
 ) (string, error) {

--- a/internal/tableland/impl/mesa_test.go
+++ b/internal/tableland/impl/mesa_test.go
@@ -847,7 +847,7 @@ func (acl *aclHalfMock) CheckPrivileges(
 	return aclImpl.CheckPrivileges(ctx, tx, controller, id, op)
 }
 
-func (acl *aclHalfMock) IsOwner(ctx context.Context, controller common.Address, id tables.TableID) (bool, error) {
+func (acl *aclHalfMock) IsOwner(_ context.Context, _ common.Address, _ tables.TableID) (bool, error) {
 	return true, nil
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -196,7 +196,12 @@ func (c *Client) List(ctx context.Context) ([]TableInfo, error) {
 		c.chain.ID,
 		c.wallet.Address().Hex(),
 	)
-	res, err := c.tblHTTP.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %v", err)
+	}
+	req = req.WithContext(ctx)
+	res, err := c.tblHTTP.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("calling http endpoint: %v", err)
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -139,7 +139,7 @@ func (acl *aclHalfMock) CheckPrivileges(
 	return aclImpl.CheckPrivileges(ctx, tx, controller, id, op)
 }
 
-func (acl *aclHalfMock) IsOwner(ctx context.Context, controller common.Address, id tables.TableID) (bool, error) {
+func (acl *aclHalfMock) IsOwner(_ context.Context, _ common.Address, _ tables.TableID) (bool, error) {
 	return true, nil
 }
 

--- a/pkg/eventprocessor/eventfeed/impl/eventfeed.go
+++ b/pkg/eventprocessor/eventfeed/impl/eventfeed.go
@@ -224,22 +224,22 @@ func (ef *EventFeed) packEvents(logs []types.Log, parsedEvents []interface{}) []
 	}
 
 	var ret []*eventfeed.BlockEvents
-	var new *eventfeed.BlockEvents
+	var newEvents *eventfeed.BlockEvents
 	for i, l := range logs {
 		// New block number detected? -> Close the block grouping.
-		if new == nil || new.BlockNumber != int64(l.BlockNumber) {
-			new = &eventfeed.BlockEvents{
+		if newEvents == nil || newEvents.BlockNumber != int64(l.BlockNumber) {
+			newEvents = &eventfeed.BlockEvents{
 				BlockNumber: int64(l.BlockNumber),
 			}
-			ret = append(ret, new)
+			ret = append(ret, newEvents)
 		}
 		// New txn hash detected? -> Close the txn hash event grouping, and continue with the next.
-		if len(new.Txns) == 0 || new.Txns[len(new.Txns)-1].TxnHash.String() != l.TxHash.String() {
-			new.Txns = append(new.Txns, eventfeed.TxnEvents{
+		if len(newEvents.Txns) == 0 || newEvents.Txns[len(newEvents.Txns)-1].TxnHash.String() != l.TxHash.String() {
+			newEvents.Txns = append(newEvents.Txns, eventfeed.TxnEvents{
 				TxnHash: l.TxHash,
 			})
 		}
-		new.Txns[len(new.Txns)-1].Events = append(new.Txns[len(new.Txns)-1].Events, parsedEvents[i])
+		newEvents.Txns[len(newEvents.Txns)-1].Events = append(newEvents.Txns[len(newEvents.Txns)-1].Events, parsedEvents[i])
 	}
 
 	return ret

--- a/pkg/eventprocessor/impl/eventprocessor_test.go
+++ b/pkg/eventprocessor/impl/eventprocessor_test.go
@@ -419,11 +419,11 @@ func setup(t *testing.T) (
 type aclMock struct{}
 
 func (acl *aclMock) CheckPrivileges(
-	ctx context.Context,
-	tx *sql.Tx,
-	controller common.Address,
-	id tables.TableID,
-	op tableland.Operation,
+	_ context.Context,
+	_ *sql.Tx,
+	_ common.Address,
+	_ tables.TableID,
+	_ tableland.Operation,
 ) (bool, error) {
 	return true, nil
 }

--- a/pkg/eventprocessor/impl/executor/impl/executor_test.go
+++ b/pkg/eventprocessor/impl/executor/impl/executor_test.go
@@ -256,11 +256,11 @@ func newParser(t *testing.T, prefixes []string) parsing.SQLValidator {
 type aclMock struct{}
 
 func (acl *aclMock) CheckPrivileges(
-	ctx context.Context,
-	tx *sql.Tx,
-	controller common.Address,
-	id tables.TableID,
-	op tableland.Operation,
+	_ context.Context,
+	_ *sql.Tx,
+	_ common.Address,
+	_ tables.TableID,
+	_ tableland.Operation,
 ) (bool, error) {
 	return true, nil
 }

--- a/pkg/eventprocessor/impl/executor/impl/txnscope_runsql_test.go
+++ b/pkg/eventprocessor/impl/executor/impl/txnscope_runsql_test.go
@@ -369,8 +369,8 @@ func TestRunSQL_RowCountLimit(t *testing.T) {
 	require.Equal(t, rowLimit, tableRowCountT100(t, dbURI, "select count(*) from foo_1337_100"))
 
 	// The next insert should fail.
-	error := insertRow(t)
-	require.Contains(t, *error,
+	err := insertRow(t)
+	require.Contains(t, *err,
 		fmt.Sprintf("table maximum row count exceeded (before %d, after %d)", rowLimit, rowLimit+1),
 	)
 
@@ -501,8 +501,8 @@ func TestWithCheck(t *testing.T) {
 		require.Equal(t, rowLimit, tableRowCountT100(t, dbURI, "select count(*) from foo_1337_100"))
 
 		// The next insert should fail.
-		error := insertRow(t)
-		require.Contains(t, *error,
+		err := insertRow(t)
+		require.Contains(t, *err,
 			fmt.Sprintf("table maximum row count exceeded (before %d, after %d)", rowLimit, rowLimit+1))
 		require.NoError(t, ex.Close(ctx))
 	})

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -32,7 +32,7 @@ func SetupLogger(version string, debug, human bool) {
 
 type googleSeverityHook struct{}
 
-func (h googleSeverityHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
+func (h googleSeverityHook) Run(e *zerolog.Event, level zerolog.Level, _ string) {
 	e.Str("severity", levelToSeverity(level).String())
 }
 

--- a/pkg/nonce/impl/simpletracker.go
+++ b/pkg/nonce/impl/simpletracker.go
@@ -42,11 +42,11 @@ func (t *SimpleTracker) GetNonce(ctx context.Context) (nonce.RegisterPendingTx, 
 }
 
 // GetPendingCount returns the number of pendings txs.
-func (t *SimpleTracker) GetPendingCount(ctx context.Context) int {
+func (t *SimpleTracker) GetPendingCount(_ context.Context) int {
 	return 0
 }
 
 // Resync is a noop for SimpleTracker.
-func (t *SimpleTracker) Resync(ctx context.Context) error {
+func (t *SimpleTracker) Resync(_ context.Context) error {
 	return nil
 }

--- a/pkg/nonce/impl/tracker_test.go
+++ b/pkg/nonce/impl/tracker_test.go
@@ -423,12 +423,12 @@ func TestCheckIfPendingTxIsStuck(t *testing.T) {
 type ChainMock struct{}
 
 // Using this for TestInitialization.
-func (m *ChainMock) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+func (m *ChainMock) PendingNonceAt(_ context.Context, _ common.Address) (uint64, error) {
 	return 10, nil
 }
 
 // Using this for test TestMinBlockDepth and TestCheckIfPendingTxIsStuck.
-func (m *ChainMock) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+func (m *ChainMock) TransactionReceipt(_ context.Context, txHash common.Hash) (*types.Receipt, error) {
 	if txHash.Hex() == "0x119f50bf7f1ff2daa4712119af9dbd429ab727690565f93193f63650b020bc30" {
 		r := &types.Receipt{BlockNumber: big.NewInt(1)}
 		return r, nil
@@ -444,30 +444,30 @@ func (m *ChainMock) TransactionReceipt(ctx context.Context, txHash common.Hash) 
 }
 
 // this is not used by any test.
-func (m *ChainMock) HeaderByNumber(ctx context.Context, n *big.Int) (*types.Header, error) {
+func (m *ChainMock) HeaderByNumber(_ context.Context, _ *big.Int) (*types.Header, error) {
 	return nil, nil
 }
 
 // this is not used by any test.
-func (m *ChainMock) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+func (m *ChainMock) BalanceAt(_ context.Context, _ common.Address, _ *big.Int) (*big.Int, error) {
 	return nil, nil
 }
 
 // this is not used by any test.
 func (m *ChainMock) TransactionByHash(
-	ctx context.Context,
-	hash common.Hash,
+	_ context.Context,
+	_ common.Hash,
 ) (tx *types.Transaction, isPending bool, err error) {
 	return nil, true, nil
 }
 
 // this is not used by any test.
-func (m *ChainMock) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+func (m *ChainMock) SendTransaction(_ context.Context, _ *types.Transaction) error {
 	return nil
 }
 
 // this is not used by any test.
-func (m *ChainMock) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+func (m *ChainMock) SuggestGasPrice(_ context.Context) (*big.Int, error) {
 	return big.NewInt(0), nil
 }
 

--- a/pkg/sqlstore/impl/system/store.go
+++ b/pkg/sqlstore/impl/system/store.go
@@ -293,7 +293,7 @@ func (s *SystemStore) WithTx(tx *sql.Tx) sqlstore.SystemStore {
 }
 
 // Begin returns a new tx.
-func (s *SystemStore) Begin(ctx context.Context) (*sql.Tx, error) {
+func (s *SystemStore) Begin(_ context.Context) (*sql.Tx, error) {
 	return s.db.Begin()
 }
 


### PR DESCRIPTION
Updated so `make lint` uses the current `golangci-lint` version `1.49.0`. 

With `golangci-lint` version `1.49.0`, and now using Go 0.19, the `revive` linter is quite powerful. I configured `golangci-lint` to use the recommended revive settings listed at https://github.com/mgechev/revive#recommended-configuration, but disabled the `package-comments` rule because I don't feel like I can provide meaningful package comments in one sweep right now. If we want to start using package comments, I'd say we should put the proper effort in where/when necessary, then we can enable the rule.