### PR TITLE
eventfeed/eventspersistance: exclude incorrect error log

### DIFF
--- a/pkg/eventprocessor/eventfeed/impl/eventfeed.go
+++ b/pkg/eventprocessor/eventfeed/impl/eventfeed.go
@@ -2,6 +2,7 @@ package impl
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -393,7 +394,7 @@ func (ef *EventFeed) persistEvents(ctx context.Context, events []types.Log, pars
 		return fmt.Errorf("opening db tx: %s", err)
 	}
 	defer func() {
-		if err := tx.Rollback(); err != nil {
+		if err := tx.Rollback(); err != nil && err != sql.ErrTxDone {
 			ef.log.Error().Err(err).Msg("persist events rollback txn")
 		}
 	}()


### PR DESCRIPTION
Looking at the logs I see this error message `sql: transaction has already been committed or rolled back`, which looked odd.

That message corresponds to `sql.ErrTxDone`, which signals that you can't do any further operation in the transaction since it was already finished (Committed or Rollbacked).

Our idiom was fine since it is a good practice always to defer a rollback to cover any error-early-return case, so we roll back the transaction. If the execution was fine (and thus Committed), Rollback is a noop. 

The problem here was that it only makes sense to log the Rollback error if isn't `sql.ErrTxDone` (which signals that there was a commit since all went fine).