### PR TITLE
Change EventFeed chain sync mechanics to impact Ethereum node SaaS costs

### DIFF
--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -81,10 +81,10 @@ type ChainConfig struct {
 		PrivateKey string `default:""`
 	}
 	EventFeed struct {
-		ChainAPIBackoff string `default:"15s"`
-		MinBlockDepth   int    `default:"5"`
-		NewBlockTimeout string `default:"30s"`
-		PersistEvents   bool   `default:"true"`
+		ChainAPIBackoff  string `default:"15s"`
+		MinBlockDepth    int    `default:"5"`
+		NewBlockPollFreq string `default:"10s"`
+		PersistEvents    bool   `default:"true"`
 	}
 	EventProcessor struct {
 		BlockFailedExecutionBackoff string `default:"10s"`

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -321,14 +321,14 @@ func createChainIDStack(
 	if err != nil {
 		return chains.ChainStack{}, fmt.Errorf("parsing chain api backoff duration: %s", err)
 	}
-	newBlockTimeout, err := time.ParseDuration(config.EventFeed.NewBlockTimeout)
+	newBlockPollFreq, err := time.ParseDuration(config.EventFeed.NewBlockPollFreq)
 	if err != nil {
 		return chains.ChainStack{}, fmt.Errorf("parsing chain api backoff duration: %s", err)
 	}
 	efOpts := []eventfeed.Option{
 		eventfeed.WithChainAPIBackoff(chainAPIBackoff),
 		eventfeed.WithMinBlockDepth(config.EventFeed.MinBlockDepth),
-		eventfeed.WithNewBlockTimeout(newBlockTimeout),
+		eventfeed.WithNewHeadPollFreq(newBlockPollFreq),
 		eventfeed.WithEventPersistence(config.EventFeed.PersistEvents),
 		eventfeed.WithFetchExtraBlockInformation(fetchExtraBlockInfo),
 	}

--- a/docker/deployed/staging/api/config.json
+++ b/docker/deployed/staging/api/config.json
@@ -30,17 +30,17 @@
   "Analytics": {
     "FetchExtraBlockInfo": false
   },
-  "Backup" : {
-		"Enabled": true,
-		"Dir": "backups",               
-		"Frequency": 120,
-		"EnableVacuum": true,      
-		"EnableCompression": true,
-    "Pruning" : {
-        "Enabled": true,
-        "KeepFiles": 5
+  "Backup": {
+    "Enabled": true,
+    "Dir": "backups",
+    "Frequency": 120,
+    "EnableVacuum": true,
+    "EnableCompression": true,
+    "Pruning": {
+      "Enabled": true,
+      "KeepFiles": 5
     }
-	},
+  },
   "Chains": [
     {
       "Name": "Optimism Kovan",
@@ -55,7 +55,7 @@
       },
       "EventFeed": {
         "ChainAPIBackoff": "15s",
-        "NewBlockTimeout": "30s",
+        "NewBlockPollFreq": "10s",
         "MinBlockDepth": 0,
         "PersistEvents": false
       },
@@ -83,7 +83,7 @@
       },
       "EventFeed": {
         "ChainAPIBackoff": "15s",
-        "NewBlockTimeout": "30s",
+        "NewBlockPollFreq": "10s",
         "MinBlockDepth": 0,
         "PersistEvents": false
       },

--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -31,17 +31,17 @@
     "Analytics": {
         "FetchExtraBlockInfo": true
     },
-    "Backup" : {
-		"Enabled": true, 
-		"Dir": "backups",               
-		"Frequency": 240,  
-		"EnableVacuum": true,      
-		"EnableCompression": true,
-        "Pruning" : {
+    "Backup": {
+        "Enabled": true,
+        "Dir": "backups",
+        "Frequency": 240,
+        "EnableVacuum": true,
+        "EnableCompression": true,
+        "Pruning": {
             "Enabled": true,
             "KeepFiles": 5
         }
-	},
+    },
     "Chains": [
         {
             "Name": "Optimism Kovan",
@@ -56,7 +56,7 @@
             },
             "EventFeed": {
                 "ChainAPIBackoff": "15s",
-                "NewBlockTimeout": "30s",
+                "NewBlockPollFreq": "5s",
                 "MinBlockDepth": 0,
                 "PersistEvents": true
             },
@@ -84,7 +84,7 @@
             },
             "EventFeed": {
                 "ChainAPIBackoff": "15s",
-                "NewBlockTimeout": "45s",
+                "NewBlockPollFreq": "10s",
                 "MinBlockDepth": 1,
                 "PersistEvents": true
             },
@@ -112,7 +112,7 @@
             },
             "EventFeed": {
                 "ChainAPIBackoff": "15s",
-                "NewBlockTimeout": "30s",
+                "NewBlockPollFreq": "5s",
                 "MinBlockDepth": 1,
                 "PersistEvents": true
             },
@@ -140,7 +140,7 @@
             },
             "EventFeed": {
                 "ChainAPIBackoff": "15s",
-                "NewBlockTimeout": "60s",
+                "NewBlockPollFreq": "10s",
                 "MinBlockDepth": 1,
                 "PersistEvents": true
             },
@@ -168,7 +168,7 @@
             },
             "EventFeed": {
                 "ChainAPIBackoff": "15s",
-                "NewBlockTimeout": "60s",
+                "NewBlockPollFreq": "5s",
                 "MinBlockDepth": 1,
                 "PersistEvents": true
             },
@@ -196,7 +196,7 @@
             },
             "EventFeed": {
                 "ChainAPIBackoff": "15s",
-                "NewBlockTimeout": "60s",
+                "NewBlockPollFreq": "5s",
                 "MinBlockDepth": 0,
                 "PersistEvents": true
             },
@@ -224,7 +224,7 @@
             },
             "EventFeed": {
                 "ChainAPIBackoff": "15s",
-                "NewBlockTimeout": "60s",
+                "NewBlockPollFreq": "5s",
                 "MinBlockDepth": 0,
                 "PersistEvents": true
             },
@@ -252,7 +252,7 @@
             },
             "EventFeed": {
                 "ChainAPIBackoff": "15s",
-                "NewBlockTimeout": "30s",
+                "NewBlockPollFreq": "5s",
                 "MinBlockDepth": 0,
                 "PersistEvents": true
             },

--- a/docker/local/api/config.json
+++ b/docker/local/api/config.json
@@ -21,7 +21,7 @@
       },
       "EventFeed": {
         "ChainAPIBackoff": "15s",
-        "NewBlockTimeout": "30s",
+        "NewBlockPollFreq": "1s",
         "MinBlockDepth": 1
       },
       "EventProcessor": {

--- a/internal/tableland/impl/mesa_test.go
+++ b/internal/tableland/impl/mesa_test.go
@@ -959,7 +959,7 @@ func (b *tablelandSetupBuilder) build(t *testing.T) *tablelandSetup {
 
 	// Spin up dependencies needed for the EventProcessor.
 	// i.e: Executor, Parser, and EventFeed (connected to the EVM chain)
-	ef, err := efimpl.New(store, 1337, backend, addr, eventfeed.WithMinBlockDepth(0))
+	ef, err := efimpl.New(store, 1337, backend, addr, eventfeed.WithNewHeadPollFreq(time.Millisecond), eventfeed.WithMinBlockDepth(0))
 	require.NoError(t, err)
 
 	// Create EventProcessor for our test.

--- a/internal/tableland/impl/mesa_test.go
+++ b/internal/tableland/impl/mesa_test.go
@@ -959,7 +959,12 @@ func (b *tablelandSetupBuilder) build(t *testing.T) *tablelandSetup {
 
 	// Spin up dependencies needed for the EventProcessor.
 	// i.e: Executor, Parser, and EventFeed (connected to the EVM chain)
-	ef, err := efimpl.New(store, 1337, backend, addr, eventfeed.WithNewHeadPollFreq(time.Millisecond), eventfeed.WithMinBlockDepth(0))
+	ef, err := efimpl.New(store,
+		1337,
+		backend,
+		addr,
+		eventfeed.WithNewHeadPollFreq(time.Millisecond),
+		eventfeed.WithMinBlockDepth(0))
 	require.NoError(t, err)
 
 	// Create EventProcessor for our test.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -242,7 +242,7 @@ func setup(t *testing.T) clientCalls {
 
 	// Spin up dependencies needed for the EventProcessor.
 	// i.e: Executor, Parser, and EventFeed (connected to the EVM chain)
-	ef, err := efimpl.New(store, 1337, backend, addr, eventfeed.WithMinBlockDepth(0))
+	ef, err := efimpl.New(store, 1337, backend, addr, eventfeed.WithNewHeadPollFreq(time.Millisecond), eventfeed.WithMinBlockDepth(0))
 	require.NoError(t, err)
 
 	// Create EventProcessor for our test.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -242,7 +242,13 @@ func setup(t *testing.T) clientCalls {
 
 	// Spin up dependencies needed for the EventProcessor.
 	// i.e: Executor, Parser, and EventFeed (connected to the EVM chain)
-	ef, err := efimpl.New(store, 1337, backend, addr, eventfeed.WithNewHeadPollFreq(time.Millisecond), eventfeed.WithMinBlockDepth(0))
+	ef, err := efimpl.New(
+		store,
+		1337,
+		backend,
+		addr,
+		eventfeed.WithNewHeadPollFreq(time.Millisecond),
+		eventfeed.WithMinBlockDepth(0))
 	require.NoError(t, err)
 
 	// Create EventProcessor for our test.

--- a/pkg/eventprocessor/eventfeed/impl/eventfeed_test.go
+++ b/pkg/eventprocessor/eventfeed/impl/eventfeed_test.go
@@ -30,7 +30,13 @@ func TestRunSQLEvents(t *testing.T) {
 	require.NoError(t, err)
 
 	backend, addr, sc, authOpts, _ := testutil.Setup(t)
-	ef, err := New(systemStore, 1337, backend, addr, eventfeed.WithNewHeadPollFreq(time.Millisecond), eventfeed.WithMinBlockDepth(0))
+	ef, err := New(
+		systemStore,
+		1337,
+		backend,
+		addr,
+		eventfeed.WithNewHeadPollFreq(time.Millisecond),
+		eventfeed.WithMinBlockDepth(0))
 	require.NoError(t, err)
 
 	// Create the table
@@ -290,7 +296,13 @@ func TestInfura(t *testing.T) {
 	dbURI := tests.Sqlite3URI()
 	systemStore, err := system.New(dbURI, tableland.ChainID(1337))
 	require.NoError(t, err)
-	ef, err := New(systemStore, 1337, conn, rinkebyContractAddr, eventfeed.WithNewHeadPollFreq(time.Second), eventfeed.WithMinBlockDepth(0))
+	ef, err := New(
+		systemStore,
+		1337,
+		conn,
+		rinkebyContractAddr,
+		eventfeed.WithNewHeadPollFreq(time.Second),
+		eventfeed.WithMinBlockDepth(0))
 	require.NoError(t, err)
 
 	ctx, cls := context.WithCancel(context.Background())

--- a/pkg/eventprocessor/eventfeed/impl/eventfeed_test.go
+++ b/pkg/eventprocessor/eventfeed/impl/eventfeed_test.go
@@ -30,7 +30,7 @@ func TestRunSQLEvents(t *testing.T) {
 	require.NoError(t, err)
 
 	backend, addr, sc, authOpts, _ := testutil.Setup(t)
-	ef, err := New(systemStore, 1337, backend, addr, eventfeed.WithMinBlockDepth(0))
+	ef, err := New(systemStore, 1337, backend, addr, eventfeed.WithNewHeadPollFreq(time.Millisecond), eventfeed.WithMinBlockDepth(0))
 	require.NoError(t, err)
 
 	// Create the table
@@ -110,6 +110,7 @@ func TestAllEvents(t *testing.T) {
 		1337,
 		backend,
 		addr,
+		eventfeed.WithNewHeadPollFreq(time.Millisecond),
 		eventfeed.WithMinBlockDepth(0),
 		eventfeed.WithEventPersistence(true),
 		eventfeed.WithFetchExtraBlockInformation(true))
@@ -289,7 +290,7 @@ func TestInfura(t *testing.T) {
 	dbURI := tests.Sqlite3URI()
 	systemStore, err := system.New(dbURI, tableland.ChainID(1337))
 	require.NoError(t, err)
-	ef, err := New(systemStore, 1337, conn, rinkebyContractAddr, eventfeed.WithMinBlockDepth(0))
+	ef, err := New(systemStore, 1337, conn, rinkebyContractAddr, eventfeed.WithNewHeadPollFreq(time.Second), eventfeed.WithMinBlockDepth(0))
 	require.NoError(t, err)
 
 	ctx, cls := context.WithCancel(context.Background())

--- a/pkg/eventprocessor/impl/eventprocessor_test.go
+++ b/pkg/eventprocessor/impl/eventprocessor_test.go
@@ -322,7 +322,13 @@ func setup(t *testing.T) (
 
 	systemStore, err := system.New(dbURI, tableland.ChainID(chainID))
 	require.NoError(t, err)
-	ef, err := efimpl.New(systemStore, chainID, backend, addr, eventfeed.WithNewHeadPollFreq(time.Millisecond), eventfeed.WithMinBlockDepth(0))
+	ef, err := efimpl.New(
+		systemStore,
+		chainID,
+		backend,
+		addr,
+		eventfeed.WithNewHeadPollFreq(time.Millisecond),
+		eventfeed.WithMinBlockDepth(0))
 	require.NoError(t, err)
 
 	// Create EventProcessor for our test.

--- a/pkg/eventprocessor/impl/eventprocessor_test.go
+++ b/pkg/eventprocessor/impl/eventprocessor_test.go
@@ -322,7 +322,7 @@ func setup(t *testing.T) (
 
 	systemStore, err := system.New(dbURI, tableland.ChainID(chainID))
 	require.NoError(t, err)
-	ef, err := efimpl.New(systemStore, chainID, backend, addr, eventfeed.WithMinBlockDepth(0))
+	ef, err := efimpl.New(systemStore, chainID, backend, addr, eventfeed.WithNewHeadPollFreq(time.Millisecond), eventfeed.WithMinBlockDepth(0))
 	require.NoError(t, err)
 
 	// Create EventProcessor for our test.

--- a/pkg/sqlstore/impl/system_store_instrumented.go
+++ b/pkg/sqlstore/impl/system_store_instrumented.go
@@ -338,7 +338,6 @@ func (s *InstrumentedSystemStore) GetBlocksMissingExtraInfo(
 	ctx context.Context,
 	fromHeight *int64,
 ) ([]int64, error) {
-	log.Debug().Msg("call GetBlocksMissingExtraInfo")
 	start := time.Now()
 	blockNumbers, err := s.store.GetBlocksMissingExtraInfo(ctx, fromHeight)
 	latency := time.Since(start).Milliseconds()
@@ -379,7 +378,6 @@ func (s *InstrumentedSystemStore) GetBlockExtraInfo(
 
 // InsertBlockExtraInfo implements sqlstore.SystemStore.
 func (s *InstrumentedSystemStore) InsertBlockExtraInfo(ctx context.Context, blockNumber int64, timestamp uint64) error {
-	log.Debug().Int64("block_number", blockNumber).Msg("call InsertBlockExtraInfo")
 	start := time.Now()
 	err := s.store.InsertBlockExtraInfo(ctx, blockNumber, timestamp)
 	latency := time.Since(start).Milliseconds()


### PR DESCRIPTION
# Summary
This PR changes the mechanics of how `EventFeed` works. We detected new blocks using a subscription-api to be notified about new blocks in the chain. That's fine since it's an efficient way to know when to get recent events from chains.

It has a downside related to Ethereum node API calls, mostly in supported chains with fast block production, such as Optimism chains. In those cases, we're having a lot of activity in these subscriptions and other downstream API calls with reactivity that isn't required.

This PR switches the mechanics to do polling with a configurable delay which means:
1) The validator operator can put a cap on how fast to react getting new blocks to have an efficient tradeoff. For example, receiving a stream of new blocks of 10 blocks per second is inefficient since 99% of those blocks won't have events of interest. 
2) On chains that have a ~fixed block production rate, e.g. Ethereum ~12s, we can set a poll time of ~12s which usually can be hardly distinguishable from a subscription by the nature of block propagation (and if we're strict, potentially block-offset consideration for reorg coverage)
3) Apart from point 2) regarding that can be ~equivalent to subscription mode, the validator operator can stretch the poll time to sync every two or more blocks on average to drive the costs down, even more, making a tradeoff between reactivity and expenses.

# Context
This situation was bubbled by looking at our validator Ethereum node API SaaS costs. We expect this will help put a cap on costs in very active chains with a disproportionate share of the expenses in our validator.

# Implementation overview
The implementation doesn't have any hacks or complexities apart from what one would naturally expect, but here're some extra notes:
1) The previous `NewBlockTimeout` configuration attribute was deleted since this configuration was used for subscription mode. The value was used to configure how the subscription healthiness was managed. Now it isn't needed.
2) A new `NewBlockPollFreq` configuration attribute was created, indicating the poll frequency for the chain.

The `EventFeed` goroutines got simplified a bit due to the nature of the change.

I've also tried to reduce some noise in logging some instrumented calls that don't add much information and make the validator output very noisy. We should probably keep working on this to improve the high logs signal even at Debug level.

This PR has been running for a while in staging and the dashboard looks healthy reg sync metrics.