### PR TITLE
Adjust local config to add hash calculation step

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -347,10 +347,10 @@ func createChainIDStack(
 	}
 	ep, err := epimpl.New(parser, ex, ef, config.ChainID, epOpts...)
 	if err != nil {
-		return chains.ChainStack{}, fmt.Errorf("creating event processor")
+		return chains.ChainStack{}, fmt.Errorf("creating event processor: %s", err)
 	}
 	if err := ep.Start(); err != nil {
-		return chains.ChainStack{}, fmt.Errorf("starting event processor")
+		return chains.ChainStack{}, fmt.Errorf("starting event processor: %s", err)
 	}
 	return chains.ChainStack{
 		Store:                 systemStore,

--- a/docker/local/api/config.json
+++ b/docker/local/api/config.json
@@ -31,7 +31,8 @@
         "CheckInterval": "10s",
         "StuckInterval": "10m",
         "MinBlockDepth": 1
-      }
+      },
+      "HashCalculationStep": 100
     }
   ]
 }


### PR DESCRIPTION
`local` was failing because the default 0 for `HashCalculationStep` config is not accepted. This PR adds a value to `local/api/config.json` to avoid 0 being the default. 

cc @joewagner 