### PR TITLE
Fixes bug in wei balance metric and updates parser

### DIFF
--- a/docker/observability/grafana/provisioning/dashboards/validator-dashboard.json
+++ b/docker/observability/grafana/provisioning/dashboards/validator-dashboard.json
@@ -356,7 +356,7 @@
             "uid": "P1809F7CD0C75ACF3"
           },
           "exemplar": true,
-          "expr": "sum by (chain_id) (tableland_wallettracker_balance_wei{service_name=\"tableland:api\"})/1000000000000000000",
+          "expr": "sum by (chain_id) (tableland_wallettracker_balance_wei{service_name=\"tableland:api\"})/1000000000",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2813,7 +2813,7 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/spf13/cobra v1.5.0
 	github.com/spruceid/siwe-go v0.2.1-0.20220711143404-817846826282
 	github.com/stretchr/testify v1.8.0
-	github.com/tablelandnetwork/sqlparser v0.0.0-20220830151425-aec4df78e4c8
+	github.com/tablelandnetwork/sqlparser v0.0.0-20220923130758-1b39431a2fea
 	github.com/textileio/cli v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.32.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -1293,8 +1293,8 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a h1:1ur3QoCqvE5fl+nylMaIr9PVV1w343YRDtsy+Rwu7XI=
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
-github.com/tablelandnetwork/sqlparser v0.0.0-20220830151425-aec4df78e4c8 h1:4sqEmxrC4M27a4pDUhw7WFrrbD3GbFS/8iYiQ3M5hJw=
-github.com/tablelandnetwork/sqlparser v0.0.0-20220830151425-aec4df78e4c8/go.mod h1:hEWKQ1CaX9T+3GgbIkgkcLk4x2V4wuWWC1fB6Kzfthg=
+github.com/tablelandnetwork/sqlparser v0.0.0-20220923130758-1b39431a2fea h1:tKGomA8Eu3t1v9SDPz2Zu3Fq2ESPQKoGzVS39PzGxmU=
+github.com/tablelandnetwork/sqlparser v0.0.0-20220923130758-1b39431a2fea/go.mod h1:hEWKQ1CaX9T+3GgbIkgkcLk4x2V4wuWWC1fB6Kzfthg=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/textileio/cli v1.0.2 h1:qSp/x4d/9SZ93TxhgZnE5okRKqzqHqrzAwKAPjuPw50=
 github.com/textileio/cli v1.0.2/go.mod h1:vTlCvvVyOmXXLwddCcBg3PDavfUsCkRBZoyr6Nu1lkc=

--- a/pkg/nonce/impl/tracker.go
+++ b/pkg/nonce/impl/tracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -373,8 +374,15 @@ func (t *LocalTracker) checkBalance() error {
 
 		return fmt.Errorf("get balance: %s", err)
 	}
+
+	s := weiBalance.String()
+	gWeiBalance, err := strconv.ParseInt(s[:len(s)-9], 10, 64)
+	if err != nil {
+		return fmt.Errorf("converting wei to gwei: %s", err)
+	}
+
 	t.mu.Lock()
-	t.currWeiBalance = weiBalance.Int64()
+	t.currWeiBalance = gWeiBalance
 	t.ethClientUnhealthy = 0
 	t.mu.Unlock()
 


### PR DESCRIPTION
One of our node operators reported a negative balance in the dashboard for his wallet:

![image](https://user-images.githubusercontent.com/1233473/191986837-f861f78d-4754-4fd8-837a-06a276eca457.png)

The problem is that we were converting `big.int` to `int64` and the balance was wrapping around and becoming negative. 

The solution was to treat the balance as `gWei` and not `wei` by removing the trailing 9 digits. 

cc @carsonfarmer 

---
This PR also updates the parser to the version that disallows the functions:
- date
- time
- datetime
- julianday
- unixepoch
- strftime

See [PR](https://github.com/tablelandnetwork/go-sqlparser/pull/12).
