### PR TITLE
Fix WAL checkpoint starvation due to unclosed migration connections

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -85,7 +85,6 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("creating executors db")
 	}
-	executorsDB.SetMaxIdleConns(0)
 	executorsDB.SetMaxOpenConns(1)
 	if err := otelsql.RegisterDBStatsMetrics(
 		executorsDB,

--- a/internal/system/impl/sqlstore_test.go
+++ b/internal/system/impl/sqlstore_test.go
@@ -27,7 +27,7 @@ var chainID = tableland.ChainID(1337)
 func TestSystemSQLStoreService(t *testing.T) {
 	t.Parallel()
 
-	dbURI := tests.Sqlite3URI()
+	dbURI := tests.Sqlite3URI(t)
 
 	ctx := context.WithValue(context.Background(), middlewares.ContextKeyChainID, tableland.ChainID(1337))
 	store, err := system.New(dbURI, chainID)
@@ -102,7 +102,7 @@ func TestSystemSQLStoreService(t *testing.T) {
 func TestGetSchemaByTableName(t *testing.T) {
 	t.Parallel()
 
-	dbURI := tests.Sqlite3URI()
+	dbURI := tests.Sqlite3URI(t)
 
 	ctx := context.WithValue(context.Background(), middlewares.ContextKeyChainID, tableland.ChainID(1337))
 	store, err := system.New(dbURI, chainID)
@@ -164,7 +164,7 @@ func TestGetSchemaByTableName(t *testing.T) {
 func TestGetMetadata(t *testing.T) {
 	t.Parallel()
 
-	dbURI := tests.Sqlite3URI()
+	dbURI := tests.Sqlite3URI(t)
 
 	ctx := context.WithValue(context.Background(), middlewares.ContextKeyChainID, tableland.ChainID(1337))
 	store, err := system.New(dbURI, chainID)
@@ -290,7 +290,7 @@ func TestEVMEventPersistence(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	dbURI := tests.Sqlite3URI()
+	dbURI := tests.Sqlite3URI(t)
 
 	store, err := system.New(dbURI, chainID)
 	require.NoError(t, err)

--- a/internal/tableland/impl/mesa_test.go
+++ b/internal/tableland/impl/mesa_test.go
@@ -943,7 +943,7 @@ func (b *tablelandSetupBuilder) withParsingOpts(opts ...parsing.Option) *tablela
 
 func (b *tablelandSetupBuilder) build(t *testing.T) *tablelandSetup {
 	t.Helper()
-	dbURI := tests.Sqlite3URI()
+	dbURI := tests.Sqlite3URI(t)
 
 	ctx := context.Background()
 	store, err := system.New(dbURI, tableland.ChainID(1337))

--- a/pkg/backup/backuper.go
+++ b/pkg/backup/backuper.go
@@ -247,7 +247,6 @@ func open(uri string) (DB, error) {
 	if err != nil {
 		return nil, errors.Errorf("opening db: %s", err)
 	}
-	db.SetMaxIdleConns(0)
 	db.SetMaxOpenConns(1)
 
 	if err := db.Ping(); err != nil {
@@ -287,7 +286,6 @@ type BackupResult struct {
 type DB interface {
 	Close() error
 	Ping() error
-	SetMaxIdleConns(n int)
 	SetMaxOpenConns(n int)
 	Conn(context.Context) (*sql.Conn, error)
 	Exec(query string, args ...interface{}) (sql.Result, error)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -183,7 +183,7 @@ func setup(t *testing.T) clientCalls {
 
 	ctx := context.Background()
 
-	dbURI := tests.Sqlite3URI()
+	dbURI := tests.Sqlite3URI(t)
 
 	store, err := system.New(dbURI, tableland.ChainID(1337))
 	require.NoError(t, err)

--- a/pkg/dbhash/dbhash_test.go
+++ b/pkg/dbhash/dbhash_test.go
@@ -23,7 +23,7 @@ func TestDatabaseHash(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
-			dbURI := tests.Sqlite3URI()
+			dbURI := tests.Sqlite3URI(t)
 
 			db, err := sql.Open("sqlite3", dbURI)
 			require.NoError(t, err)

--- a/pkg/eventprocessor/eventfeed/impl/eventfeed_test.go
+++ b/pkg/eventprocessor/eventfeed/impl/eventfeed_test.go
@@ -25,7 +25,7 @@ var emptyHash = common.HexToHash("0x0")
 func TestRunSQLEvents(t *testing.T) {
 	t.Parallel()
 
-	dbURI := tests.Sqlite3URI()
+	dbURI := tests.Sqlite3URI(t)
 	systemStore, err := system.New(dbURI, tableland.ChainID(1337))
 	require.NoError(t, err)
 
@@ -105,7 +105,7 @@ func TestRunSQLEvents(t *testing.T) {
 func TestAllEvents(t *testing.T) {
 	t.Parallel()
 
-	dbURI := tests.Sqlite3URI()
+	dbURI := tests.Sqlite3URI(t)
 	systemStore, err := system.New(dbURI, tableland.ChainID(1337))
 	require.NoError(t, err)
 
@@ -293,7 +293,7 @@ func TestInfura(t *testing.T) {
 	require.NoError(t, err)
 	rinkebyContractAddr := common.HexToAddress("0x847645b7dAA32eFda757d3c10f1c82BFbB7b41D0")
 
-	dbURI := tests.Sqlite3URI()
+	dbURI := tests.Sqlite3URI(t)
 	systemStore, err := system.New(dbURI, tableland.ChainID(1337))
 	require.NoError(t, err)
 	ef, err := New(

--- a/pkg/eventprocessor/impl/eventprocessor_replayhistory_test.go
+++ b/pkg/eventprocessor/impl/eventprocessor_replayhistory_test.go
@@ -82,7 +82,6 @@ func launchValidatorForAllChainsBackedByEVMHistory(t *testing.T, historyDBURI st
 
 	db, err := sql.Open("sqlite3", dbURI)
 	require.NoError(t, err)
-	db.SetMaxIdleConns(0)
 	db.SetMaxOpenConns(1)
 
 	chains := getChains(t, historyDBURI)

--- a/pkg/eventprocessor/impl/eventprocessor_replayhistory_test.go
+++ b/pkg/eventprocessor/impl/eventprocessor_replayhistory_test.go
@@ -76,7 +76,7 @@ func TestReplayProductionHistory(t *testing.T) {
 }
 
 func launchValidatorForAllChainsBackedByEVMHistory(t *testing.T, historyDBURI string) ([]*EventProcessor, func()) {
-	dbURI := tests.Sqlite3URI()
+	dbURI := tests.Sqlite3URI(t)
 	parser, err := parserimpl.New([]string{"system_", "registry", "sqlite_"})
 	require.NoError(t, err)
 

--- a/pkg/eventprocessor/impl/eventprocessor_test.go
+++ b/pkg/eventprocessor/impl/eventprocessor_test.go
@@ -314,7 +314,7 @@ func setup(t *testing.T) (
 
 	// Spin up dependencies needed for the EventProcessor.
 	// i.e: Executor, Parser, and EventFeed (connected to the EVM chain)
-	dbURI := tests.Sqlite3URI()
+	dbURI := tests.Sqlite3URI(t)
 	parser, err := parserimpl.New([]string{"system_", "registry", "sqlite_"})
 	require.NoError(t, err)
 

--- a/pkg/eventprocessor/impl/executor/impl/executor_test.go
+++ b/pkg/eventprocessor/impl/executor/impl/executor_test.go
@@ -190,7 +190,7 @@ func existsTableWithName(t *testing.T, dbURI string, tableName string) bool {
 func newExecutor(t *testing.T, rowsLimit int) (*Executor, string) {
 	t.Helper()
 
-	dbURI := tests.Sqlite3URI()
+	dbURI := tests.Sqlite3URI(t)
 
 	parser := newParser(t, []string{})
 	db, err := sql.Open("sqlite3", dbURI)

--- a/pkg/nonce/impl/tracker_test.go
+++ b/pkg/nonce/impl/tracker_test.go
@@ -138,7 +138,7 @@ func TestInitialization(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	url := tests.Sqlite3URI()
+	url := tests.Sqlite3URI(t)
 
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -210,7 +210,7 @@ func TestMinBlockDepth(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	url := tests.Sqlite3URI()
+	url := tests.Sqlite3URI(t)
 
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -367,7 +367,7 @@ func TestCheckIfPendingTxIsStuck(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	url := tests.Sqlite3URI()
+	url := tests.Sqlite3URI(t)
 
 	key, err := crypto.GenerateKey()
 	require.NoError(t, err)
@@ -479,7 +479,7 @@ func setup(ctx context.Context, t *testing.T) (
 	*wallet.Wallet,
 	sqlstore.SystemStore,
 ) {
-	url := tests.Sqlite3URI()
+	url := tests.Sqlite3URI(t)
 
 	backend, _, contract, txOptsFrom, sk := testutil.Setup(t)
 

--- a/pkg/sqlstore/impl/system/store.go
+++ b/pkg/sqlstore/impl/system/store.go
@@ -500,6 +500,11 @@ func (s *SystemStore) executeMigration(dbURI string, as *bindata.AssetSource) er
 	if err != nil {
 		return fmt.Errorf("creating migration: %s", err)
 	}
+	defer func() {
+		if _, err := m.Close(); err != nil {
+			s.log.Error().Err(err).Msg("closing db migration")
+		}
+	}()
 	version, dirty, err := m.Version()
 	s.log.Info().
 		Uint("dbVersion", version).

--- a/pkg/sqlstore/impl/system/store.go
+++ b/pkg/sqlstore/impl/system/store.go
@@ -49,7 +49,6 @@ func New(dbURI string, chainID tableland.ChainID) (*SystemStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("connecting to db: %s", err)
 	}
-	dbc.SetMaxIdleConns(0)
 	if err := otelsql.RegisterDBStatsMetrics(dbc, otelsql.WithAttributes(
 		attribute.String("name", "systemstore"),
 		attribute.Int64("chain_id", int64(chainID)),

--- a/pkg/sqlstore/impl/user/store.go
+++ b/pkg/sqlstore/impl/user/store.go
@@ -28,7 +28,6 @@ func New(dbURI string) (*UserStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("connecting to db: %s", err)
 	}
-	db.SetMaxIdleConns(0)
 	if err := otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(
 		attribute.String("name", "userstore"),
 	)); err != nil {

--- a/pkg/sqlstore/impl/user/store_test.go
+++ b/pkg/sqlstore/impl/user/store_test.go
@@ -14,7 +14,7 @@ import (
 func TestReadGeneralTypeCorrectness(t *testing.T) {
 	t.Parallel()
 
-	db, err := sql.Open("sqlite3", tests.Sqlite3URI())
+	db, err := sql.Open("sqlite3", tests.Sqlite3URI(t))
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/pkg/tables/impl/ethereum/client_test.go
+++ b/pkg/tables/impl/ethereum/client_test.go
@@ -445,7 +445,7 @@ func setupWithLocalTracker(t *testing.T) (
 	w, err := wallet.NewWallet(hex.EncodeToString(crypto.FromECDSA(key)))
 	require.NoError(t, err)
 
-	url := tests.Sqlite3URI()
+	url := tests.Sqlite3URI(t)
 
 	systemStore, err := system.New(url, tableland.ChainID(1337))
 	require.NoError(t, err)

--- a/pkg/telemetry/storage/db.go
+++ b/pkg/telemetry/storage/db.go
@@ -35,7 +35,6 @@ func New(dbURI string) (*TelemetryDatabase, error) {
 	if err != nil {
 		return nil, fmt.Errorf("connecting to db: %s", err)
 	}
-	sqlDB.SetMaxIdleConns(0)
 	if err := otelsql.RegisterDBStatsMetrics(sqlDB, otelsql.WithAttributes(
 		attribute.String("name", "telemetrydb"),
 	)); err != nil {

--- a/pkg/telemetry/storage/db.go
+++ b/pkg/telemetry/storage/db.go
@@ -178,6 +178,11 @@ func (db *TelemetryDatabase) executeMigration(dbURI string, as *bindata.AssetSou
 	if err != nil {
 		return fmt.Errorf("creating migration: %s", err)
 	}
+	defer func() {
+		if _, err := m.Close(); err != nil {
+			db.log.Error().Err(err).Msg("closing db migration")
+		}
+	}()
 	version, dirty, err := m.Version()
 	db.log.Info().
 		Uint("dbVersion", version).

--- a/pkg/telemetry/storage/db_test.go
+++ b/pkg/telemetry/storage/db_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestCollectAndFetchAndPublish(t *testing.T) {
 	t.Run("state hash", func(t *testing.T) {
-		dbURI := tests.Sqlite3URI()
+		dbURI := tests.Sqlite3URI(t)
 		s, err := New(dbURI)
 		require.NoError(t, err)
 		telemetry.SetMetricStore(s)

--- a/tests/sqlite3.go
+++ b/tests/sqlite3.go
@@ -1,10 +1,25 @@
 package tests
 
 import (
+	"context"
+	"database/sql"
+	"testing"
+
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 )
 
 // Sqlite3URI returns a URI to spinup an in-memory Sqlite database.
-func Sqlite3URI() string {
-	return "file::" + uuid.NewString() + ":?mode=memory&cache=shared&_foreign_keys=on"
+func Sqlite3URI(t *testing.T) string {
+	dbURI := "file::" + uuid.NewString() + ":?mode=memory&cache=shared&_foreign_keys=on"
+	db, err := sql.Open("sqlite3", dbURI)
+	require.NoError(t, err)
+	conn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		conn.Close()
+		db.Close()
+	})
+
+	return dbURI
 }

--- a/tests/sqlite3.go
+++ b/tests/sqlite3.go
@@ -17,8 +17,8 @@ func Sqlite3URI(t *testing.T) string {
 	conn, err := db.Conn(context.Background())
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		conn.Close()
-		db.Close()
+		_ = conn.Close()
+		_ = db.Close()
 	})
 
 	return dbURI


### PR DESCRIPTION
# Summary

This PR fixes a bug where we didn't properly close database connections used for database migrations.
I've checked in my local validator and tested that with/without this change, my WAL file does/doesn't get checkpointed.

I've also removed the `MaxIdleConns(0)`, which always forces us to open a new connection, which we've seen has a considerable hit on the overall performance of the validator. Let's get back to square one now that this _should_ be fixed and stop paying a performance penalty that didn't even fixed/alleviated the problem.

Note that we're trying to avoid as much as possible having any background goroutine to force checkpointing and let the natural behavior of SQLite be enough. Considering we found the source of the problem, we'll see now if that's the case.

Closes #312.

# Context

See #312.

# Implementation overview

The current fix and other changes don't require much explanation. The way I found this was by spinning up partially wired validators, and checking locally if the WAL gets checkpointed. The interesting part was that the graceful closing of the main wiring was correct, so _apparently_ all looked fine. After a while, I landed on the side-channel db pool created for migrations.


There was an interesting side-effect of fixing this bug on tests.

After fixing this bug, I saw most tests fail since expected system tables _didn't exist_. This might sound surprising at first, but it makes sense (and is even a further validation that this fix works). In memory, databases in SQLite get deleted when the last open connection closes. When we spin up test stacks, we don't have "warmed up" any db connection pool, so before running the tests, there aren't open connections; thus, the in-memory `dbURI` is destroyed.

When we had the bug, this didn't happen since our system store (or other deps) ran table migrations. And these migrations weren't closing their database connection, so at least there was always one active database connection preventing the in-memory database from being destroyed.

The fix for this is quite simple and means always forcing a single connection to be opened in every in-memory database so it doesn't get destroyed if there are no active database connections at any point in time. See the PR comments for more info.


# Implementation details and review orientation

Not required.

# Checklist
- [X]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [X]  Are changes covered by existing tests, or were new tests included?
- [X]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [X]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
