### PR TITLE
nonce: bug fix if the balance is below 1gwei

### DIFF
--- a/pkg/nonce/impl/tracker.go
+++ b/pkg/nonce/impl/tracker.go
@@ -376,9 +376,12 @@ func (t *LocalTracker) checkBalance() error {
 	}
 
 	s := weiBalance.String()
-	gWeiBalance, err := strconv.ParseInt(s[:len(s)-9], 10, 64)
-	if err != nil {
-		return fmt.Errorf("converting wei to gwei: %s", err)
+	var gWeiBalance int64
+	if len(s) > 9 {
+		gWeiBalance, err = strconv.ParseInt(s[:len(s)-9], 10, 64)
+		if err != nil {
+			return fmt.Errorf("converting wei to gwei: %s", err)
+		}
 	}
 
 	t.mu.Lock()


### PR DESCRIPTION
# Summary

This PR fixes a panic cause if the balance of a wallet is less than 1gWei due to slicing.

# Context

A node operator reported this bug.

# Implementation overview

If the balance is less than 1gWei, we round to 0.

# Implementation details and review orientation

Not needed.

# Checklist

- [X]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [X]  Are changes covered by existing tests, or were new tests included?
- [X]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [X]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?