### PR TITLE
healthbot: add fast recovery mode

### DIFF
--- a/cmd/healthbot/counterprobe/counterprobe.go
+++ b/cmd/healthbot/counterprobe/counterprobe.go
@@ -91,14 +91,19 @@ func (cp *CounterProbe) Run(ctx context.Context) {
 	if err := cp.execProbe(ctx); err != nil {
 		cp.log.Error().Err(err).Msg("health check failed")
 	}
+
+	checkInterval := cp.checkInterval
 	for {
 		select {
 		case <-ctx.Done():
 			cp.log.Info().Msg("closing gracefully...")
 			return
-		case <-time.After(cp.checkInterval):
+		case <-time.After(checkInterval):
 			if err := cp.execProbe(ctx); err != nil {
 				cp.log.Error().Err(err).Msg("health check failed")
+				checkInterval = time.Minute
+			} else {
+				checkInterval = cp.checkInterval
 			}
 		}
 	}


### PR DESCRIPTION
# Summary

This PR gives the healthbot a _fast recovery_ mode to increase probe frequency if the last check fails.

# Context

In chains where we have probes with _long frequencies_, it's a bit annoying that if a probe fails, it will wait for a full cycle to do the next probe. For example, in Goerli we do probes every hour, and in other chains every ~5min.

If for whatever reason, the probe is failing, it doesn't sound reasonable to wait for a full cycle for two reasons:
- If the cause of the failure required some action that we fixed, we want to know as soon as possible if healthbot is green again.
- If the cause of the failure is infra-related, we'd have alerts firing even if that failure lasted 10s.

# Implementation overview

The idea of the PR is that if a probe fails, it will change the frequency to _every minute_. I think this is a _reasonable_ hardcoded value that we can experiment with. Technically speaking, the healthbot shouldn't be in this state often so I'm not sure it's worth an extra configuration knob in the config file (it's quite easy to add, anyway).

I tried to avoid fancier policies like `frequency/2` or similar since I don't think is fine as a solution. If the probe has 1hr frequency, switching to 30min still feels quite slow to detect the recovery. Similarly, if we have 60s probes, 30s might be too aggressive.

The bottom line is defaulting to having a recovery mode that runs every minute if the last probe fails. Whenever we have a successful probe, we switch to the chain-configured frequency.

# Implementation details and review orientation

Not required.

