### PR TITLE
Adds animation_url to table's metadata

### DIFF
--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -21,9 +21,8 @@ type config struct {
 	Dir                string // This will default to "", NOT the default dir value set via the flag package
 	BootstrapBackupURL string `default:"" env:"BOOTSTRAP_BACKUP_URL"`
 
-	HTTP    HTTPConfig
-	Gateway GatewayConfig
-
+	HTTP             HTTPConfig
+	Gateway          GatewayConfig
 	TableConstraints TableConstraints
 	QueryConstraints QueryConstraints
 
@@ -56,8 +55,9 @@ type HTTPConfig struct {
 
 // GatewayConfig contains configuration for the Gateway.
 type GatewayConfig struct {
-	ExternalURIPrefix   string `default:"https://testnet.tableland.network"`
-	MetadataRendererURI string `default:""`
+	ExternalURIPrefix    string `default:"https://testnet.tableland.network"`
+	MetadataRendererURI  string `default:""`
+	AnimationRendererURI string `default:""`
 }
 
 // BackupConfig contains configuration for automatic database backups.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -483,6 +483,7 @@ func createHTTPServer(
 	router := router.ConfiguredRouter(
 		gatewayConfig.ExternalURIPrefix,
 		gatewayConfig.MetadataRendererURI,
+		gatewayConfig.MetadataRendererURI,
 		httpConfig.MaxRequestPerInterval,
 		rateLimInterval,
 		parser,

--- a/docker/deployed/staging/api/config.json
+++ b/docker/deployed/staging/api/config.json
@@ -8,7 +8,8 @@
   },
   "Gateway": {
     "ExternalURIPrefix": "https://staging.tableland.network",
-    "MetadataRendererURI": ""
+    "MetadataRendererURI": "",
+    "AnimationRendererURI": ""
   },
   "DB": {
     "Port": "5432"

--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -9,7 +9,8 @@
     },
     "Gateway": {
         "ExternalURIPrefix": "https://testnet.tableland.network",
-        "MetadataRendererURI": "https://render.tableland.xyz"
+        "MetadataRendererURI": "https://render.tableland.xyz",
+        "AnimationRendererURI": "https://render.tableland.xyz/anim"
     },
     "DB": {
         "Port": "5432"

--- a/docker/local/api/config.json
+++ b/docker/local/api/config.json
@@ -5,7 +5,8 @@
   },
   "Gateway": {
     "ExternalURIPrefix": "http://localhost:8080",
-    "MetadataRendererURI": ""
+    "MetadataRendererURI": "",
+    "AnimationRendererURI": ""
   },
   "Chains": [
     {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -24,6 +24,7 @@ import (
 func ConfiguredRouter(
 	extURLPrefix string,
 	metadataRendererURI string,
+	animationRendererURI string,
 	maxRPI uint64,
 	rateLimInterval time.Duration,
 	parser parsing.SQLValidator,
@@ -53,7 +54,7 @@ func ConfiguredRouter(
 	for chainID, stack := range chainStacks {
 		stores[chainID] = stack.Store
 	}
-	sysStore, err := systemimpl.NewSystemSQLStoreService(stores, extURLPrefix, metadataRendererURI)
+	sysStore, err := systemimpl.NewSystemSQLStoreService(stores, extURLPrefix, metadataRendererURI, animationRendererURI)
 	if err != nil {
 		log.Fatal().Err(err).Msg("creating system store")
 	}

--- a/internal/system/impl/sqlstore.go
+++ b/internal/system/impl/sqlstore.go
@@ -53,6 +53,21 @@ func NewSystemSQLStoreService(
 	if _, err := url.ParseRequestURI(extURLPrefix); err != nil {
 		return nil, fmt.Errorf("invalid external url prefix: %s", err)
 	}
+
+	metadataRendererURI = strings.TrimRight(metadataRendererURI, "/")
+	if metadataRendererURI != "" {
+		if _, err := url.ParseRequestURI(metadataRendererURI); err != nil {
+			return nil, fmt.Errorf("metadata renderer uri could not be parsed: %s", err)
+		}
+	}
+
+	animationRendererURI = strings.TrimRight(animationRendererURI, "/")
+	if animationRendererURI != "" {
+		if _, err := url.ParseRequestURI(animationRendererURI); err != nil {
+			return nil, fmt.Errorf("animation renderer uri could not be parsed: %s", err)
+		}
+	}
+
 	return &SystemSQLStoreService{
 		extURLPrefix:         extURLPrefix,
 		metadataRendererURI:  metadataRendererURI,
@@ -178,27 +193,14 @@ func (s *SystemSQLStoreService) getMetadataImage(chainID tableland.ChainID, tabl
 		return DefaultMetadataImage
 	}
 
-	uri := strings.TrimRight(s.metadataRendererURI, "/")
-	if _, err := url.ParseRequestURI(uri); err != nil {
-		log.Warn().Str("uri", uri).Msg("metadata renderer uri could not be parsed")
-		return DefaultMetadataImage
-	}
-
-	return fmt.Sprintf("%s/%d/%s", uri, chainID, tableID)
+	return fmt.Sprintf("%s/%d/%s", s.metadataRendererURI, chainID, tableID)
 }
 
 func (s *SystemSQLStoreService) getAnimationURL(chainID tableland.ChainID, tableID tables.TableID) string {
 	if s.animationRendererURI == "" {
 		return DefaultAnimationURL
 	}
-
-	uri := strings.TrimRight(s.animationRendererURI, "/")
-	if _, err := url.ParseRequestURI(uri); err != nil {
-		log.Warn().Str("uri", uri).Msg("metadata renderer uri could not be parsed")
-		return DefaultAnimationURL
-	}
-
-	return fmt.Sprintf("%s/?chain=%d&id=%s", uri, chainID, tableID)
+	return fmt.Sprintf("%s/?chain=%d&id=%s", s.animationRendererURI, chainID, tableID)
 }
 
 func (s *SystemSQLStoreService) emptyMetadataImage() string {

--- a/internal/system/impl/sqlstore_test.go
+++ b/internal/system/impl/sqlstore_test.go
@@ -66,7 +66,7 @@ func TestSystemSQLStoreService(t *testing.T) {
 	require.NoError(t, bs.Close())
 
 	stack := map[tableland.ChainID]sqlstore.SystemStore{1337: store}
-	svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "https://render.tableland.xyz")
+	svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "https://render.tableland.xyz", "")
 	require.NoError(t, err)
 	metadata, err := svc.GetTableMetadata(ctx, id)
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestGetSchemaByTableName(t *testing.T) {
 	require.NoError(t, bs.Close())
 
 	stack := map[tableland.ChainID]sqlstore.SystemStore{1337: store}
-	svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "https://render.tableland.xyz")
+	svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "https://render.tableland.xyz", "")
 	require.NoError(t, err)
 
 	schema, err := svc.GetSchemaByTableName(ctx, "foo_1337_42")
@@ -207,7 +207,7 @@ func TestGetMetadata(t *testing.T) {
 	t.Run("empty metadata uri", func(t *testing.T) {
 		t.Parallel()
 
-		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "")
+		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "", "")
 		require.NoError(t, err)
 
 		metadata, err := svc.GetTableMetadata(ctx, id)
@@ -223,7 +223,7 @@ func TestGetMetadata(t *testing.T) {
 	t.Run("with metadata uri", func(t *testing.T) {
 		t.Parallel()
 
-		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "https://render.tableland.xyz")
+		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "https://render.tableland.xyz", "")
 		require.NoError(t, err)
 
 		metadata, err := svc.GetTableMetadata(ctx, id)
@@ -239,7 +239,7 @@ func TestGetMetadata(t *testing.T) {
 	t.Run("with metadata uri trailing slash", func(t *testing.T) {
 		t.Parallel()
 
-		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "https://render.tableland.xyz/")
+		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "https://render.tableland.xyz/", "")
 		require.NoError(t, err)
 
 		metadata, err := svc.GetTableMetadata(ctx, id)
@@ -255,7 +255,7 @@ func TestGetMetadata(t *testing.T) {
 	t.Run("with wrong metadata uri", func(t *testing.T) {
 		t.Parallel()
 
-		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "foo")
+		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "foo", "")
 		require.NoError(t, err)
 
 		metadata, err := svc.GetTableMetadata(ctx, id)
@@ -271,7 +271,7 @@ func TestGetMetadata(t *testing.T) {
 	t.Run("non existent table", func(t *testing.T) {
 		t.Parallel()
 
-		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "foo")
+		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "foo", "")
 		require.NoError(t, err)
 
 		id, _ := tables.NewTableID("43")
@@ -283,6 +283,28 @@ func TestGetMetadata(t *testing.T) {
 		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
 		require.Equal(t, "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nNTEyJyBoZWlnaHQ9JzUxMicgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJz48cmVjdCB3aWR0aD0nNTEyJyBoZWlnaHQ9JzUxMicgZmlsbD0nIzAwMCcvPjwvc3ZnPg==", metadata.Image) // nolint
 		require.Equal(t, "Table not found", metadata.Message)
+	})
+
+	t.Run("with metadata uri and animation uri", func(t *testing.T) {
+		t.Parallel()
+
+		svc, err := NewSystemSQLStoreService(
+			stack,
+			"https://tableland.network/tables",
+			"https://render.tableland.xyz",
+			"https://render.tableland.xyz/anim",
+		)
+		require.NoError(t, err)
+
+		metadata, err := svc.GetTableMetadata(ctx, id)
+		require.NoError(t, err)
+
+		require.Equal(t, "foo_1337_42", metadata.Name)
+		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
+		require.Equal(t, "https://render.tableland.xyz/1337/42", metadata.Image)
+		require.Equal(t, "https://render.tableland.xyz/anim/?chain=1337&id=42", metadata.AnimationURL)
+		require.Equal(t, "date", metadata.Attributes[0].DisplayType)
+		require.Equal(t, "created", metadata.Attributes[0].TraitType)
 	})
 }
 

--- a/internal/system/impl/sqlstore_test.go
+++ b/internal/system/impl/sqlstore_test.go
@@ -255,23 +255,15 @@ func TestGetMetadata(t *testing.T) {
 	t.Run("with wrong metadata uri", func(t *testing.T) {
 		t.Parallel()
 
-		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "foo", "")
-		require.NoError(t, err)
-
-		metadata, err := svc.GetTableMetadata(ctx, id)
-		require.NoError(t, err)
-
-		require.Equal(t, "foo_1337_42", metadata.Name)
-		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
-		require.Equal(t, DefaultMetadataImage, metadata.Image)
-		require.Equal(t, "date", metadata.Attributes[0].DisplayType)
-		require.Equal(t, "created", metadata.Attributes[0].TraitType)
+		_, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "foo", "")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "metadata renderer uri could not be parsed")
 	})
 
 	t.Run("non existent table", func(t *testing.T) {
 		t.Parallel()
 
-		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "foo", "")
+		svc, err := NewSystemSQLStoreService(stack, "https://tableland.network/tables", "https://render.tableland.xyz", "")
 		require.NoError(t, err)
 
 		id, _ := tables.NewTableID("43")

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -226,6 +226,7 @@ func setup(t *testing.T) clientCalls {
 	router := router.ConfiguredRouter(
 		"https://testnet.tableland.network",
 		"https://render.tableland.xyz",
+		"",
 		10,
 		time.Second,
 		parser,

--- a/pkg/sqlstore/table.go
+++ b/pkg/sqlstore/table.go
@@ -38,11 +38,12 @@ type ColumnSchema struct {
 
 // TableMetadata represents table metadata (OpenSea standard).
 type TableMetadata struct {
-	Name        string                   `json:"name,omitempty"`
-	ExternalURL string                   `json:"external_url"`
-	Image       string                   `json:"image"`
-	Message     string                   `json:"message,omitempty"`
-	Attributes  []TableMetadataAttribute `json:"attributes,omitempty"`
+	Name         string                   `json:"name,omitempty"`
+	ExternalURL  string                   `json:"external_url"`
+	Image        string                   `json:"image"`
+	Message      string                   `json:"message,omitempty"`
+	AnimationURL string                   `json:"animation_url,omitempty"`
+	Attributes   []TableMetadataAttribute `json:"attributes,omitempty"`
 }
 
 // TableMetadataAttribute represents the table metadata attribute.


### PR DESCRIPTION
# Summary

Adds `animation_url` property to the response of Table's metadata call `GET /chain/{chainID}/tables/{id}`

Closes #326 

cc @awmuncy 

# Context

An HTML app (light version of the dashboard) pointed by `animation_url` address will be rendered on most NFT marketplaces when the Table NFT details page is opened. 

# Implementation overview

Adds a new config `AnimationRendererURI`. In `testnet` it points to `https://render.tableland.xyz/anim/`. In other envs it's just an empty string, which means the `animation_url` won't be shown. 

# Implementation details and review orientation
n/a

# Checklist

- [x]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [x]  Are changes covered by existing tests, or were new tests included?
- [x]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [x]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
