### PR TITLE
Telemetry: add binary git summary & last executed block number per chain id

### DIFF
--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -38,9 +38,20 @@ func GetSummary() Summary {
 	return summary
 }
 
-func (s Summary) GetGitCommit() string     { return s.GitCommit }
-func (s Summary) GetGitBranch() string     { return s.GitBranch }
-func (s Summary) GetGitState() string      { return s.GitState }
-func (s Summary) GetGitSummary() string    { return s.GitSummary }
-func (s Summary) GetBuildDate() string     { return s.BuildDate }
+// GetGitCommit returns the GitCommit.
+func (s Summary) GetGitCommit() string { return s.GitCommit }
+
+// GetGitBranch returns the GitBranch.
+func (s Summary) GetGitBranch() string { return s.GitBranch }
+
+// GetGitState returns the GitState.
+func (s Summary) GetGitState() string { return s.GitState }
+
+// GetGitSummary returns the GitSummary.
+func (s Summary) GetGitSummary() string { return s.GitSummary }
+
+// GetBuildDate returns the build date.
+func (s Summary) GetBuildDate() string { return s.BuildDate }
+
+// GetBinaryVersion returns the binary version.
 func (s Summary) GetBinaryVersion() string { return s.Version }

--- a/buildinfo/buildinfo.go
+++ b/buildinfo/buildinfo.go
@@ -25,7 +25,7 @@ type Summary struct {
 	Version    string
 }
 
-// GetSummary returns a JSON string with a summary of git information.
+// GetSummary returns a summary of git information.
 func GetSummary() Summary {
 	summary := Summary{
 		GitCommit:  GitCommit,
@@ -37,3 +37,10 @@ func GetSummary() Summary {
 	}
 	return summary
 }
+
+func (s Summary) GetGitCommit() string     { return s.GitCommit }
+func (s Summary) GetGitBranch() string     { return s.GitBranch }
+func (s Summary) GetGitState() string      { return s.GitState }
+func (s Summary) GetGitSummary() string    { return s.GitSummary }
+func (s Summary) GetBuildDate() string     { return s.BuildDate }
+func (s Summary) GetBinaryVersion() string { return s.Version }

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -55,12 +55,14 @@ type config struct {
 			KeepFiles int  `default:"5"` // number of files to keep
 		}
 	}
-	TelemetryPublisher struct {
-		Enabled            bool   `default:"false"`
-		MetricsHubURL      string `default:""`
-		MetricsHubAPIKey   string `default:""`
-		PublishingInterval string `default:"10s"`
-	}
+	TelemetryPublisher TelemetryPublisherConfig
+}
+
+type TelemetryPublisherConfig struct {
+	Enabled            bool   `default:"false"`
+	MetricsHubURL      string `default:""`
+	MetricsHubAPIKey   string `default:""`
+	PublishingInterval string `default:"10s"`
 }
 
 // TableConstraints describes contraints to be enforced for Tableland tables.

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -63,6 +63,8 @@ type TelemetryPublisherConfig struct {
 	MetricsHubURL      string `default:""`
 	MetricsHubAPIKey   string `default:""`
 	PublishingInterval string `default:"10s"`
+
+	ChainStackCollectFrequency string `default:"15m"`
 }
 
 // TableConstraints describes contraints to be enforced for Tableland tables.

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -58,6 +58,7 @@ type config struct {
 	TelemetryPublisher TelemetryPublisherConfig
 }
 
+// TelemetryPublisherConfig contains configuration attributes for the telemetry module.
 type TelemetryPublisherConfig struct {
 	Enabled            bool   `default:"false"`
 	MetricsHubURL      string `default:""`

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -456,7 +456,7 @@ func configureTelemetry(
 	}()
 
 	// Module closing function
-	close := func(ctx context.Context) error {
+	return func(ctx context.Context) error {
 		clsChainStackCollector()
 		<-chainStackCollectorClosed
 
@@ -468,7 +468,5 @@ func configureTelemetry(
 		}
 
 		return nil
-	}
-
-	return close, nil
+	}, nil
 }

--- a/docker/deployed/staging/api/config.json
+++ b/docker/deployed/staging/api/config.json
@@ -45,7 +45,8 @@
     "Enabled": true,
     "MetricsHubURL": "https://metricshub-staging-mrgr43cf5q-uw.a.run.app",
     "MetricsHubApiKey": "${METRICS_HUB_API_KEY}",
-    "PublishingInterval": "10s"
+    "PublishingInterval": "10s",
+    "ChainStackCollectFrequency": "15m"
   },
   "Chains": [
     {

--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -46,7 +46,8 @@
         "Enabled": true,
         "MetricsHubURL": "https://metricshub-testnet-mrgr43cf5q-uw.a.run.app",
         "MetricsHubApiKey": "${METRICS_HUB_API_KEY}",
-        "PublishingInterval": "10s"
+        "PublishingInterval": "10s",
+        "ChainStackCollectFrequency": "15m"
     },
     "Chains": [
         {

--- a/internal/chains/chains.go
+++ b/internal/chains/chains.go
@@ -3,6 +3,7 @@ package chains
 import (
 	"context"
 
+	"github.com/textileio/go-tableland/pkg/eventprocessor"
 	"github.com/textileio/go-tableland/pkg/sqlstore"
 	"github.com/textileio/go-tableland/pkg/tables"
 )
@@ -11,6 +12,7 @@ import (
 type ChainStack struct {
 	Store                 sqlstore.SystemStore
 	Registry              tables.TablelandTables
+	EventProcessor        eventprocessor.EventProcessor
 	AllowTransactionRelay bool
 
 	// close gracefully closes all the chain stack components.

--- a/pkg/eventprocessor/eventprocessor.go
+++ b/pkg/eventprocessor/eventprocessor.go
@@ -1,6 +1,7 @@
 package eventprocessor
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -66,6 +67,7 @@ func WithHashCalcStep(step int64) Option {
 
 // EventProcessor processes events from a smart-contract.
 type EventProcessor interface {
+	GetLastExecutedBlockNumber(context.Context) (int64, error)
 	Start() error
 	Stop()
 }

--- a/pkg/eventprocessor/impl/eventprocessor.go
+++ b/pkg/eventprocessor/impl/eventprocessor.go
@@ -112,6 +112,15 @@ func (ep *EventProcessor) Start() error {
 	return nil
 }
 
+func (ep *EventProcessor) GetLastExecutedBlockNumber(ctx context.Context) (int64, error) {
+	blockNumber, err := ep.executor.GetLastExecutedBlockNumber(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("get last executed block number: %s", err)
+	}
+
+	return blockNumber, nil
+}
+
 // Stop stops processing new events.
 func (ep *EventProcessor) Stop() {
 	ep.lock.Lock()

--- a/pkg/eventprocessor/impl/eventprocessor.go
+++ b/pkg/eventprocessor/impl/eventprocessor.go
@@ -112,6 +112,7 @@ func (ep *EventProcessor) Start() error {
 	return nil
 }
 
+// GetLastExecutedBlockNumber returns the last executed block number.
 func (ep *EventProcessor) GetLastExecutedBlockNumber(ctx context.Context) (int64, error) {
 	blockNumber, err := ep.executor.GetLastExecutedBlockNumber(ctx)
 	if err != nil {

--- a/pkg/telemetry/chainscollector/chainscollector.go
+++ b/pkg/telemetry/chainscollector/chainscollector.go
@@ -12,13 +12,18 @@ import (
 	"github.com/textileio/go-tableland/pkg/telemetry"
 )
 
+// ChainsCollector captures metrics from chains stacks with a defined frequency.
 type ChainsCollector struct {
 	log              zerolog.Logger
 	chainStacks      map[tableland.ChainID]chains.ChainStack
 	collectFrequency time.Duration
 }
 
-func New(chainStacks map[tableland.ChainID]chains.ChainStack, collectFrequency time.Duration) (*ChainsCollector, error) {
+// New returns a new *ChainsCollector.
+func New(
+	chainStacks map[tableland.ChainID]chains.ChainStack,
+	collectFrequency time.Duration,
+) (*ChainsCollector, error) {
 	if collectFrequency <= time.Second {
 		return nil, fmt.Errorf("collect frequency should be greater than one second")
 	}
@@ -29,6 +34,7 @@ func New(chainStacks map[tableland.ChainID]chains.ChainStack, collectFrequency t
 	}, nil
 }
 
+// Start starts collecting chains stack telemetry metrics until the context is canceled.
 func (cc *ChainsCollector) Start(ctx context.Context) {
 	for {
 		select {

--- a/pkg/telemetry/chainscollector/chainscollector.go
+++ b/pkg/telemetry/chainscollector/chainscollector.go
@@ -1,0 +1,59 @@
+package chainscollector
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog"
+	logger "github.com/rs/zerolog/log"
+	"github.com/textileio/go-tableland/internal/chains"
+	"github.com/textileio/go-tableland/internal/tableland"
+	"github.com/textileio/go-tableland/pkg/telemetry"
+)
+
+type ChainsCollector struct {
+	log              zerolog.Logger
+	chainStacks      map[tableland.ChainID]chains.ChainStack
+	collectFrequency time.Duration
+}
+
+func New(chainStacks map[tableland.ChainID]chains.ChainStack, collectFrequency time.Duration) (*ChainsCollector, error) {
+	if collectFrequency <= time.Second {
+		return nil, fmt.Errorf("collect frequency should be greater than one second")
+	}
+	return &ChainsCollector{
+		log:              logger.With().Str("component", "chainscollector").Logger(),
+		chainStacks:      chainStacks,
+		collectFrequency: collectFrequency,
+	}, nil
+}
+
+func (cc *ChainsCollector) Start(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			cc.log.Info().Msg("gracefully closed")
+			return
+		case <-time.After(cc.collectFrequency):
+			metric := make(chainIDBlockNumbers, len(cc.chainStacks))
+			for chainID, chainStack := range cc.chainStacks {
+				blockNumber, err := chainStack.EventProcessor.GetLastExecutedBlockNumber(ctx)
+				if err != nil {
+					cc.log.Error().Err(err).Msg("get last executed block number")
+					continue
+				}
+				metric[chainID] = blockNumber
+			}
+			if err := telemetry.Collect(ctx, metric); err != nil {
+				cc.log.Error().Err(err).Msg("collecting chain stack metric")
+			}
+		}
+	}
+}
+
+type chainIDBlockNumbers map[tableland.ChainID]int64
+
+func (cbn chainIDBlockNumbers) GetLastProcessedBlockNumber() map[tableland.ChainID]int64 {
+	return cbn
+}

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/textileio/go-tableland/internal/tableland"
 )
 
 // MetricType defines the metric type.
@@ -15,6 +16,8 @@ const (
 	StateHashType MetricType = iota
 	// GitSummaryType is the type for the GitSummaryMetric.
 	GitSummaryType
+	// ChainStacksSummaryType is the type for the ChainStacksMetric.
+	ChainStacksSummaryType
 )
 
 // Metric defines a metric.
@@ -72,4 +75,16 @@ type GitSummaryMetric struct {
 	GitSummary    string `json:"git_summary"`
 	BuildDate     string `json:"build_date"`
 	BinaryVersion string `json:"binary_version"`
+}
+
+// ChainStacksSummary defines how data is accessed to create a ChainStacksMetric.
+type ChainStacksSummary interface {
+	GetLastProcessedBlockNumber() map[tableland.ChainID]int64
+}
+
+// ChainStacksMetric contains information about each chain being synced.
+type ChainStacksMetric struct {
+	Version int `json:"version"`
+
+	LastProcessedBlockNumbers map[tableland.ChainID]int64 `json:"last_processed_block_number"`
 }

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -65,7 +65,7 @@ type GitSummary interface {
 	GetBinaryVersion() string
 }
 
-// GitSummary contains Git information of the binary.
+// GitSummaryMetric contains Git information of the binary.
 type GitSummaryMetric struct {
 	Version int `json:"version"`
 

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -13,6 +13,8 @@ type MetricType int
 const (
 	// StateHashType is the type for the StateHashMetric.
 	StateHashType MetricType = iota
+	// GitSummaryType is the type for the GitSummaryMetric.
+	GitSummaryType
 )
 
 // Metric defines a metric.
@@ -43,8 +45,31 @@ type StateHash interface {
 
 // StateHashMetric defines a state hash metric.
 type StateHashMetric struct {
-	Version     int64  `json:"version"`
+	Version int64 `json:"version"`
+
 	ChainID     int64  `json:"chain_id"`
 	BlockNumber int64  `json:"block_number"`
 	Hash        string `json:"hash"`
+}
+
+// GitSummary defines how data is accessed to create a VersionSummaryMetric.
+type GitSummary interface {
+	GetGitCommit() string
+	GetGitBranch() string
+	GetGitState() string
+	GetGitSummary() string
+	GetBuildDate() string
+	GetBinaryVersion() string
+}
+
+// GitSummary contains Git information of the binary.
+type GitSummaryMetric struct {
+	Version int `json:"version"`
+
+	GitCommit     string `json:"git_commit"`
+	GitBranch     string `json:"git_branch"`
+	GitState      string `json:"git_state"`
+	GitSummary    string `json:"git_summary"`
+	BuildDate     string `json:"build_date"`
+	BinaryVersion string `json:"binary_version"`
 }

--- a/pkg/telemetry/storage/db.go
+++ b/pkg/telemetry/storage/db.go
@@ -118,6 +118,13 @@ func (db *TelemetryDatabase) FetchUnpublishedMetrics(ctx context.Context, amount
 				return nil, fmt.Errorf("scan rows of system metrics: %s", err)
 			}
 			mType = telemetry.GitSummaryType
+		case telemetry.ChainStacksSummaryType:
+			mPayload = new(telemetry.ChainStacksMetric)
+			if err := json.Unmarshal(payload, mPayload); err != nil {
+				return nil, fmt.Errorf("scan rows of system metrics: %s", err)
+			}
+			mType = telemetry.ChainStacksSummaryType
+
 		default:
 			return nil, fmt.Errorf("unknown metric type: %d", typ)
 		}

--- a/pkg/telemetry/storage/db.go
+++ b/pkg/telemetry/storage/db.go
@@ -136,7 +136,6 @@ func (db *TelemetryDatabase) FetchUnpublishedMetrics(ctx context.Context, amount
 			Type:      mType,
 			Payload:   mPayload,
 		})
-
 	}
 
 	return metrics, nil

--- a/pkg/telemetry/storage/db_test.go
+++ b/pkg/telemetry/storage/db_test.go
@@ -17,12 +17,21 @@ import (
 )
 
 func TestCollectAndFetchAndPublish(t *testing.T) {
-	t.Run("state hash", func(t *testing.T) {
-		dbURI := tests.Sqlite3URI(t)
-		s, err := New(dbURI)
-		require.NoError(t, err)
-		telemetry.SetMetricStore(s)
+	t.Parallel()
 
+	// Notes:
+	// This can't be wired per sub-tests for two reasons:
+	// 1- `telemetry.SetMetricStore(...)` is a global setup at the package level, and
+	// 2- `SetMetricStore(...)` has a `sync.Once` wrapping so can't be called more than once, so each sub-test can't
+	//     override their value.
+	//
+	// This also means that sub-tests can't run in parallel.
+	dbURI := tests.Sqlite3URI(t)
+	s, err := New(dbURI)
+	require.NoError(t, err)
+	telemetry.SetMetricStore(s)
+
+	t.Run("state hash", func(t *testing.T) {
 		// collect two mocked statehash metrics
 		require.NoError(t, telemetry.Collect(context.Background(), stateHash{}))
 		require.NoError(t, telemetry.Collect(context.Background(), stateHash{}))
@@ -31,17 +40,59 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, metrics, 2)
 
-		require.Equal(t, telemetry.StateHashType, metrics[0].Type)
-		require.Equal(t, 1, metrics[0].Version)
-		require.Equal(t, stateHash{}.ChainID(), metrics[0].Payload.(*telemetry.StateHashMetric).ChainID)
-		require.Equal(t, stateHash{}.BlockNumber(), metrics[0].Payload.(*telemetry.StateHashMetric).BlockNumber)
-		require.Equal(t, stateHash{}.Hash(), metrics[0].Payload.(*telemetry.StateHashMetric).Hash)
+		for _, metric := range metrics {
+			require.Equal(t, telemetry.StateHashType, metric.Type)
+			require.Equal(t, 1, metric.Version)
+			require.False(t, metric.Timestamp.IsZero())
 
-		require.Equal(t, telemetry.StateHashType, metrics[1].Type)
-		require.Equal(t, 1, metrics[0].Version)
-		require.Equal(t, stateHash{}.ChainID(), metrics[1].Payload.(*telemetry.StateHashMetric).ChainID)
-		require.Equal(t, stateHash{}.BlockNumber(), metrics[1].Payload.(*telemetry.StateHashMetric).BlockNumber)
-		require.Equal(t, stateHash{}.Hash(), metrics[1].Payload.(*telemetry.StateHashMetric).Hash)
+			sh := metric.Payload.(*telemetry.StateHashMetric)
+			require.Equal(t, stateHash{}.ChainID(), sh.ChainID)
+			require.Equal(t, stateHash{}.BlockNumber(), sh.BlockNumber)
+			require.Equal(t, stateHash{}.Hash(), sh.Hash)
+		}
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		exporter, err := publisher.NewHTTPExporter(ts.URL, "")
+		require.NoError(t, err)
+		nodeID := strings.Replace(uuid.NewString(), "-", "", -1)
+		p := publisher.NewPublisher(s, exporter, nodeID, time.Second)
+		p.Start()
+
+		require.Eventually(t, func() bool {
+			metrics, err = s.FetchUnpublishedMetrics(context.Background(), 2)
+			require.NoError(t, err)
+			return len(metrics) == 0
+		}, 5*time.Second, time.Second)
+
+		p.Close()
+	})
+
+	t.Run("git summary", func(t *testing.T) {
+		// collect two mocked gitSummary metrics
+		require.NoError(t, telemetry.Collect(context.Background(), gitSummary{}))
+		require.NoError(t, telemetry.Collect(context.Background(), gitSummary{}))
+
+		metrics, err := s.FetchUnpublishedMetrics(context.Background(), 10)
+		require.NoError(t, err)
+		require.Len(t, metrics, 2)
+
+		for _, metric := range metrics {
+			require.Equal(t, telemetry.GitSummaryType, metric.Type)
+			require.Equal(t, 1, metric.Version)
+			require.False(t, metric.Timestamp.IsZero())
+
+			gv := metric.Payload.(*telemetry.GitSummaryMetric)
+			require.Equal(t, gitSummary{}.GetGitCommit(), gv.GitCommit)
+			require.Equal(t, gitSummary{}.GetGitBranch(), gv.GitBranch)
+			require.Equal(t, gitSummary{}.GetGitState(), gv.GitState)
+			require.Equal(t, gitSummary{}.GetGitSummary(), gv.GitSummary)
+			require.Equal(t, gitSummary{}.GetBuildDate(), gv.BuildDate)
+			require.Equal(t, gitSummary{}.GetBinaryVersion(), gv.BinaryVersion)
+		}
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -63,6 +114,15 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 		p.Close()
 	})
 }
+
+type gitSummary struct{}
+
+func (gs gitSummary) GetGitCommit() string     { return "fakeGitCommit" }
+func (gs gitSummary) GetGitBranch() string     { return "fakeGitBranch" }
+func (gs gitSummary) GetGitState() string      { return "fakeGitState" }
+func (gs gitSummary) GetGitSummary() string    { return "fakeGitSummary" }
+func (gs gitSummary) GetBuildDate() string     { return "fakeGitDate" }
+func (gs gitSummary) GetBinaryVersion() string { return "fakeBinaryVersion" }
 
 type stateHash struct{}
 

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -62,7 +62,25 @@ func Collect(ctx context.Context, metric interface{}) error {
 				Hash:        v.Hash(),
 			},
 		}); err != nil {
-			return errors.Errorf("store metric: %s", err)
+			return errors.Errorf("store state hash metric: %s", err)
+		}
+		return nil
+	case GitSummary:
+		if err := metricStore.StoreMetric(ctx, Metric{
+			Version:   1,
+			Timestamp: time.Now().UTC(),
+			Type:      GitSummaryType,
+			Payload: GitSummaryMetric{
+				Version:       1,
+				GitCommit:     v.GetGitCommit(),
+				GitBranch:     v.GetGitBranch(),
+				GitState:      v.GetGitState(),
+				GitSummary:    v.GetGitSummary(),
+				BuildDate:     v.GetBuildDate(),
+				BinaryVersion: v.GetBinaryVersion(),
+			},
+		}); err != nil {
+			return errors.Errorf("store git summary metric: %s", err)
 		}
 		return nil
 	default:

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -83,6 +83,19 @@ func Collect(ctx context.Context, metric interface{}) error {
 			return errors.Errorf("store git summary metric: %s", err)
 		}
 		return nil
+	case ChainStacksSummary:
+		if err := metricStore.StoreMetric(ctx, Metric{
+			Version:   1,
+			Timestamp: time.Now().UTC(),
+			Type:      ChainStacksSummaryType,
+			Payload: ChainStacksMetric{
+				Version:                   1,
+				LastProcessedBlockNumbers: v.GetLastProcessedBlockNumber(),
+			},
+		}); err != nil {
+			return errors.Errorf("store git summary metric: %s", err)
+		}
+		return nil
 	default:
 		return fmt.Errorf("unknown metric type %T", v)
 	}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -93,7 +93,7 @@ func Collect(ctx context.Context, metric interface{}) error {
 				LastProcessedBlockNumbers: v.GetLastProcessedBlockNumber(),
 			},
 		}); err != nil {
-			return errors.Errorf("store git summary metric: %s", err)
+			return errors.Errorf("store chains stacks summary metric: %s", err)
 		}
 		return nil
 	default:

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -22,6 +22,15 @@ func TestCollectMockedtStore(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, s.called)
 	})
+	t.Run("git summary", func(t *testing.T) {
+		s := &store{}
+		metricStore = s
+
+		require.False(t, s.called)
+		err := Collect(context.Background(), gitSummary{})
+		require.NoError(t, err)
+		require.True(t, s.called)
+	})
 }
 
 func TestCollectUnknownMetric(t *testing.T) {
@@ -33,19 +42,20 @@ func TestCollectUnknownMetric(t *testing.T) {
 	require.ErrorContains(t, err, "unknown metric")
 }
 
+type gitSummary struct{}
+
+func (gs gitSummary) GetGitCommit() string     { return "fakeGitCommit" }
+func (gs gitSummary) GetGitBranch() string     { return "fakeGitBranch" }
+func (gs gitSummary) GetGitState() string      { return "fakeGitState" }
+func (gs gitSummary) GetGitSummary() string    { return "fakeGitSummary" }
+func (gs gitSummary) GetBuildDate() string     { return "fakeGitDate" }
+func (gs gitSummary) GetBinaryVersion() string { return "fakeBinaryVersion" }
+
 type stateHash struct{}
 
-func (h stateHash) ChainID() int64 {
-	return 1
-}
-
-func (h stateHash) BlockNumber() int64 {
-	return 1
-}
-
-func (h stateHash) Hash() string {
-	return "abcdefgh"
-}
+func (h stateHash) ChainID() int64     { return 1 }
+func (h stateHash) BlockNumber() int64 { return 1 }
+func (h stateHash) Hash() string       { return "abcdefgh" }
 
 type store struct {
 	called bool

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/textileio/go-tableland/internal/tableland"
 )
 
 func TestCollectWithoutStore(t *testing.T) {
@@ -31,6 +32,16 @@ func TestCollectMockedtStore(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, s.called)
 	})
+	t.Run("chains stack summary", func(t *testing.T) {
+		s := &store{}
+		metricStore = s
+
+		require.False(t, s.called)
+
+		err := Collect(context.Background(), chainsStackSummary(map[tableland.ChainID]int64{1: 10, 2: 20}))
+		require.NoError(t, err)
+		require.True(t, s.called)
+	})
 }
 
 func TestCollectUnknownMetric(t *testing.T) {
@@ -41,6 +52,10 @@ func TestCollectUnknownMetric(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "unknown metric")
 }
+
+type chainsStackSummary map[tableland.ChainID]int64
+
+func (css chainsStackSummary) GetLastProcessedBlockNumber() map[tableland.ChainID]int64 { return css }
 
 type gitSummary struct{}
 


### PR DESCRIPTION
# Summary

This PR adds two new metrics to the optional telemetry collection:
- The Git summary of the validator binary: This will help understand if validators are running old versions.
- Last executed block number per chain: this will help to understand if validators have some healthiness problem syncing chains, lagging behind; we could infer syncing speeds or liveness since the metric is published at a fixed time-frequency.

This was tested in staging, and it's working correctly.

# Context

This is part of the objective to add optional telemetry reporting in validators.

# Implementation overview

The implementation has two main parts:
1) Git summary metrics: this is published once when the validator spins up. 
2) Last executed block number: this is done by a new telemetry sub-package, collecting the information in all `chainStacks`, and aggregating them in a single metric to be published.

# Implementation details and review orientation

No specific directions are needed. I'll add some PR comments to mention some tangential refactors.

# Checklist

- [X]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [X]  Are changes covered by existing tests, or were new tests included?
- [X]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [X]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
