### PR TITLE
otelhttp: add service name

### DIFF
--- a/internal/router/middlewares/otelhttp.go
+++ b/internal/router/middlewares/otelhttp.go
@@ -3,12 +3,23 @@ package middlewares
 import (
 	"net/http"
 
+	"github.com/textileio/go-tableland/pkg/metrics"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // OtelHTTP wraps the handler h with OTEL metrics.
 func OtelHTTP(operation string) func(h http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
-		return otelhttp.NewHandler(h, operation)
+		return otelhttp.NewHandler(&labeledHandler{h: h}, operation)
 	}
+}
+
+type labeledHandler struct {
+	h http.Handler
+}
+
+func (lh *labeledHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	labeler, _ := otelhttp.LabelerFromContext(r.Context())
+	labeler.Add(metrics.BaseAttrs...)
+	lh.h.ServeHTTP(rw, r)
 }


### PR DESCRIPTION
# Summary

This PR solves, hopefully, the last breaking change of OTEL default attributes behavioral change.

In the testnet dashboard, some tiles don't show information:
![image](https://user-images.githubusercontent.com/6136245/195415009-a6500254-ccb5-4d4c-9732-0aa221aa34c1.png)

In the staging dashboard I deployed this PR and it shows data correctly.

# Context

https://github.com/tablelandnetwork/go-tableland/pull/323

# Implementation overview

Luckily, after digging into the `otelhttp`, I saw that you can inject custom labels if you do an extra middleware wrapping.
It'll become clear while seeing the code.

# Implementation details and review orientation

NA