### PR TITLE
instrumented: add metrics.BaseAttrs 

### DIFF
--- a/internal/system/impl/sqlstore_instrumented.go
+++ b/internal/system/impl/sqlstore_instrumented.go
@@ -8,6 +8,7 @@ import (
 	"github.com/textileio/go-tableland/internal/router/middlewares"
 	"github.com/textileio/go-tableland/internal/system"
 	"github.com/textileio/go-tableland/internal/tableland"
+	"github.com/textileio/go-tableland/pkg/metrics"
 	"github.com/textileio/go-tableland/pkg/sqlstore"
 	"github.com/textileio/go-tableland/pkg/tables"
 	"go.opentelemetry.io/otel/attribute"
@@ -48,12 +49,12 @@ func (s *InstrumentedSystemSQLStoreService) GetTableMetadata(
 	chainID, _ := ctx.Value(middlewares.ContextKeyChainID).(tableland.ChainID)
 
 	// NOTE: we may face a risk of high-cardilatity in the future. This should be revised.
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("GetTableMetadata")},
 		{Key: "id", Value: attribute.StringValue(id.String())},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -70,11 +71,11 @@ func (s *InstrumentedSystemSQLStoreService) GetTablesByController(ctx context.Co
 	latency := time.Since(start).Milliseconds()
 	chainID, _ := ctx.Value(middlewares.ContextKeyChainID).(tableland.ChainID)
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("GetTablesByController")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -92,11 +93,11 @@ func (s *InstrumentedSystemSQLStoreService) GetTablesByStructure(
 	latency := time.Since(start).Milliseconds()
 	chainID, _ := ctx.Value(middlewares.ContextKeyChainID).(tableland.ChainID)
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("GetTablesByStructure")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -113,10 +114,10 @@ func (s *InstrumentedSystemSQLStoreService) GetSchemaByTableName(
 	tables, err := s.system.GetSchemaByTableName(ctx, tableName)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("GetSchemaByTableName")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)

--- a/internal/tableland/impl/mesa_instrumented.go
+++ b/internal/tableland/impl/mesa_instrumented.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/textileio/go-tableland/internal/tableland"
+	"github.com/textileio/go-tableland/pkg/metrics"
 	"github.com/textileio/go-tableland/pkg/tables"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/global"
@@ -127,11 +128,11 @@ func (t *InstrumentedTablelandMesa) SetController(
 
 func (t *InstrumentedTablelandMesa) record(ctx context.Context, data recordData) {
 	// NOTE: we may face a risk of high-cardilatity in the future. This should be revised.
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue(data.method)},
 		{Key: "table_id", Value: attribute.StringValue(data.tableID)},
 		{Key: "success", Value: attribute.BoolValue(data.success)},
-	}
+	}, metrics.BaseAttrs...)
 
 	t.callCount.Add(ctx, 1, attributes...)
 	t.latencyHistogram.Record(ctx, data.latency, attributes...)

--- a/pkg/parsing/impl/validator_instrumented.go
+++ b/pkg/parsing/impl/validator_instrumented.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/textileio/go-tableland/internal/tableland"
+	"github.com/textileio/go-tableland/pkg/metrics"
 	"github.com/textileio/go-tableland/pkg/parsing"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/global"
@@ -50,10 +51,10 @@ func (ip *InstrumentedSQLValidator) ValidateCreateTable(
 	cs, err := ip.parser.ValidateCreateTable(query, chainID)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("ValidateCreateTable")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
-	}
+	}, metrics.BaseAttrs...)
 
 	ip.callCount.Add(context.Background(), 1, attributes...)
 	ip.latencyHistogram.Record(context.Background(), latency, attributes...)
@@ -71,10 +72,10 @@ func (ip *InstrumentedSQLValidator) ValidateMutatingQuery(
 	mutatingStmts, err := ip.parser.ValidateMutatingQuery(query, chainID)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("ValidateMutatingQuery")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
-	}
+	}, metrics.BaseAttrs...)
 
 	ip.callCount.Add(context.Background(), 1, attributes...)
 	ip.latencyHistogram.Record(context.Background(), latency, attributes...)
@@ -89,10 +90,10 @@ func (ip *InstrumentedSQLValidator) ValidateReadQuery(query string) (parsing.Rea
 	readStmt, err := ip.parser.ValidateReadQuery(query)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("ValidateReadQuery")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
-	}
+	}, metrics.BaseAttrs...)
 
 	ip.callCount.Add(context.Background(), 1, attributes...)
 	ip.latencyHistogram.Record(context.Background(), latency, attributes...)

--- a/pkg/sqlstore/impl/system_store_instrumented.go
+++ b/pkg/sqlstore/impl/system_store_instrumented.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/textileio/go-tableland/internal/tableland"
 	"github.com/textileio/go-tableland/pkg/eventprocessor"
+	"github.com/textileio/go-tableland/pkg/metrics"
 	"github.com/textileio/go-tableland/pkg/nonce"
 	"github.com/textileio/go-tableland/pkg/sqlstore"
 	"github.com/textileio/go-tableland/pkg/tables"
@@ -53,12 +54,12 @@ func (s *InstrumentedSystemStore) GetTable(ctx context.Context, id tables.TableI
 	latency := time.Since(start).Milliseconds()
 
 	// NOTE: we may face a risk of high-cardilatity in the future. This should be revised.
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("GetTable")},
 		{Key: "id", Value: attribute.StringValue(id.String())},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
 
@@ -75,12 +76,12 @@ func (s *InstrumentedSystemStore) GetTablesByController(
 	latency := time.Since(start).Milliseconds()
 
 	// NOTE: we may face a risk of high-cardilatity in the future. This should be revised.
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("GetTablesByController")},
 		{Key: "controller", Value: attribute.StringValue(controller)},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -98,12 +99,12 @@ func (s *InstrumentedSystemStore) GetTablesByStructure(
 	latency := time.Since(start).Milliseconds()
 
 	// NOTE: we may face a risk of high-cardilatity in the future. This should be revised.
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("GetTablesByStructure")},
 		{Key: "structure", Value: attribute.StringValue(structure)},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -118,12 +119,12 @@ func (s *InstrumentedSystemStore) GetSchemaByTableName(ctx context.Context, name
 	latency := time.Since(start).Milliseconds()
 
 	// NOTE: we may face a risk of high-cardilatity in the future. This should be revised.
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("GetSchemaByTableName")},
 		{Key: "name", Value: attribute.StringValue(name)},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -142,12 +143,12 @@ func (s *InstrumentedSystemStore) GetACLOnTableByController(
 	latency := time.Since(start).Milliseconds()
 
 	// NOTE: we may face a risk of high-cardilatity in the future. This should be revised.
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("GetACLOnTableByController")},
 		{Key: "address", Value: attribute.StringValue(address)},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -164,11 +165,11 @@ func (s *InstrumentedSystemStore) ListPendingTx(
 	data, err := s.store.ListPendingTx(ctx, addr)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("ListPendingTx")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -187,11 +188,11 @@ func (s *InstrumentedSystemStore) InsertPendingTx(
 	err := s.store.InsertPendingTx(ctx, addr, nonce, hash)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("InsertPendingTx")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -205,11 +206,11 @@ func (s *InstrumentedSystemStore) DeletePendingTxByHash(ctx context.Context, has
 	err := s.store.DeletePendingTxByHash(ctx, hash)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("DeletePendingTxByHash")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -227,11 +228,11 @@ func (s *InstrumentedSystemStore) ReplacePendingTxByHash(
 	err := s.store.ReplacePendingTxByHash(ctx, oldHash, newHash)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("ReplacePendingTxByHash")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -264,11 +265,11 @@ func (s *InstrumentedSystemStore) GetReceipt(
 	receipt, ok, err := s.store.GetReceipt(ctx, txnHash)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("GetReceipt")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -283,11 +284,11 @@ func (s *InstrumentedSystemStore) AreEVMEventsPersisted(ctx context.Context, txn
 	ok, err := s.store.AreEVMEventsPersisted(ctx, txnHash)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("AreEVMEventsPersisted")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -302,11 +303,11 @@ func (s *InstrumentedSystemStore) SaveEVMEvents(ctx context.Context, events []ta
 	err := s.store.SaveEVMEvents(ctx, events)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("SaveEVMEvents")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -321,11 +322,11 @@ func (s *InstrumentedSystemStore) GetEVMEvents(ctx context.Context, txnHash comm
 	events, err := s.store.GetEVMEvents(ctx, txnHash)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("GetEVMEvents")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -342,11 +343,11 @@ func (s *InstrumentedSystemStore) GetBlocksMissingExtraInfo(
 	blockNumbers, err := s.store.GetBlocksMissingExtraInfo(ctx, fromHeight)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("GetBlocksMissingExtraInfo")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -364,11 +365,11 @@ func (s *InstrumentedSystemStore) GetBlockExtraInfo(
 	blockInfo, err := s.store.GetBlockExtraInfo(ctx, blockNumber)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("GetBlockExtraInfo")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -382,11 +383,11 @@ func (s *InstrumentedSystemStore) InsertBlockExtraInfo(ctx context.Context, bloc
 	err := s.store.InsertBlockExtraInfo(ctx, blockNumber, timestamp)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("InsertBlockExtraInfo")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
 		{Key: "chainID", Value: attribute.Int64Value(int64(s.chainID))},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)
@@ -400,10 +401,10 @@ func (s *InstrumentedSystemStore) GetID(ctx context.Context) (string, error) {
 	id, err := s.store.GetID(ctx)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("Id")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)

--- a/pkg/sqlstore/impl/user_store_instrumented.go
+++ b/pkg/sqlstore/impl/user_store_instrumented.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/textileio/go-tableland/internal/tableland"
+	"github.com/textileio/go-tableland/pkg/metrics"
 	"github.com/textileio/go-tableland/pkg/parsing"
 	"github.com/textileio/go-tableland/pkg/sqlstore"
 	"go.opentelemetry.io/otel/attribute"
@@ -45,10 +46,10 @@ func (s *InstrumentedUserStore) Read(ctx context.Context, stmt parsing.ReadStmt)
 	data, err := s.store.Read(ctx, stmt)
 	latency := time.Since(start).Milliseconds()
 
-	attributes := []attribute.KeyValue{
+	attributes := append([]attribute.KeyValue{
 		{Key: "method", Value: attribute.StringValue("Read")},
 		{Key: "success", Value: attribute.BoolValue(err == nil)},
-	}
+	}, metrics.BaseAttrs...)
 
 	s.callCount.Add(ctx, 1, attributes...)
 	s.latencyHistogram.Record(ctx, latency, attributes...)


### PR DESCRIPTION
# Summary

Add `metrics.BaseAttrs` to all the instrumentation middleware that registers metrics for stores/apis.

Tested in staging.

# Context

NA

# Implementation overview

NA

# Implementation details and review orientation

NA

