### PR TITLE
Improves the backup restorer to consider an existing database

### DIFF
--- a/pkg/backup/restorer/restorer.go
+++ b/pkg/backup/restorer/restorer.go
@@ -2,6 +2,7 @@ package restorer
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -101,8 +102,16 @@ func (br *BackupRestorer) load() error {
 		}
 	}()
 
-	if err := os.Remove(fmt.Sprintf("%s/%s", filepath.Dir(br.dbPath), filepath.Base(br.dbPath))); err != nil {
-		log.Warn().Err(err).Msg("removing database file")
+	dbPath := fmt.Sprintf("%s/%s", filepath.Dir(br.dbPath), filepath.Base(br.dbPath))
+	tmpDbPath := dbPath + ".tmp"
+
+	// If a database already exists we are going to rename it,
+	// so, later, we can get the node id information from the existing database.
+	dbExists := fileExists(dbPath)
+	if dbExists {
+		if err := os.Rename(dbPath, tmpDbPath); err != nil {
+			log.Warn().Err(err).Msg("renaming file")
+		}
 	}
 
 	if err := os.Remove(fmt.Sprintf("%s/%s-wal", filepath.Dir(br.dbPath), filepath.Base(br.dbPath))); err != nil {
@@ -113,7 +122,7 @@ func (br *BackupRestorer) load() error {
 		log.Warn().Err(err).Msg("removing database shm file")
 	}
 
-	out, err := os.Create(fmt.Sprintf("%s/%s", filepath.Dir(br.dbPath), filepath.Base(br.dbPath)))
+	out, err := os.Create(dbPath)
 	if err != nil {
 		return fmt.Errorf("creating file: %s", err)
 	}
@@ -128,7 +137,7 @@ func (br *BackupRestorer) load() error {
 		return fmt.Errorf("copying file: %s", err)
 	}
 
-	db, err := sql.Open("sqlite3", fmt.Sprintf("%s/%s", filepath.Dir(br.dbPath), filepath.Base(br.dbPath)))
+	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {
 		return fmt.Errorf("opening database: %s", err)
 	}
@@ -136,14 +145,29 @@ func (br *BackupRestorer) load() error {
 		if err := db.Close(); err != nil {
 			log.Error().Err(err).Msg("closing db")
 		}
+
+		if dbExists {
+			if err := os.Remove(tmpDbPath); err != nil {
+				log.Error().Err(err).Msg("closing db")
+			}
+		}
 	}()
 
-	if _, err := db.Exec("DELETE FROM system_pending_tx;"); err != nil {
-		return fmt.Errorf("deleting rows from system_pending_tx table: %s", err)
+	// we need to clean up some information not related to the node
+	if _, err := db.Exec("DELETE FROM system_pending_tx; DELETE FROM system_id;"); err != nil {
+		return fmt.Errorf("deleting rows from system_pending_tx and system_id table: %s", err)
 	}
 
-	if _, err := db.Exec("DELETE FROM system_id;"); err != nil {
-		return fmt.Errorf("deleting rows from system_id table: %s", err)
+	if dbExists {
+		// getting the node id from existing database via attach
+		sql := fmt.Sprintf(`
+			ATTACH DATABASE '%s' as tmp;
+			INSERT INTO system_id SELECT * FROM tmp.system_id;
+			INSERT INTO system_pending_tx SELECT * FROM tmp.system_pending_tx;
+		`, tmpDbPath)
+		if _, err := db.Exec(sql); err != nil {
+			return fmt.Errorf("copying information from existing database: %s", err)
+		}
 	}
 
 	return nil
@@ -159,4 +183,17 @@ func (br *BackupRestorer) cleanUp() error {
 	}
 
 	return nil
+}
+
+func fileExists(name string) bool {
+	_, err := os.Stat(name)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+
+	log.Warn().Err(err).Msg("file exists")
+	return false
 }

--- a/pkg/backup/restorer/restorer_test.go
+++ b/pkg/backup/restorer/restorer_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRestorer(t *testing.T) {
+func TestRestorerWithNoExistingDatabase(t *testing.T) {
 	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// this is a test database that contains the following tables with one record each
@@ -27,7 +27,7 @@ func TestRestorer(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	dirPath := os.TempDir()
+	dirPath := t.TempDir()
 	databaseURL := fmt.Sprintf(
 		"file://%s?_busy_timeout=5000&_foreign_keys=on&_journal_mode=WAL",
 		path.Join(dirPath, "database.db"),
@@ -53,4 +53,86 @@ func TestRestorer(t *testing.T) {
 	err = db.QueryRow("SELECT count(1) FROM system_id").Scan(&c)
 	require.NoError(t, err)
 	require.Equal(t, 0, c)
+}
+
+func TestRestorerWithExistingDatabase(t *testing.T) {
+	t.Parallel()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// this is a test database that contains the following tables with one record each
+		// "a", "system_pending_tx", "system_id"
+		f, err := os.Open("testdata/database.db.zst")
+		require.NoError(t, err)
+		data, err := io.ReadAll(f)
+		require.NoError(t, err)
+		_, _ = w.Write(data)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	dirPath := t.TempDir()
+
+	// we create an existing database with the node id information stored
+	createExistingDatabase(t, dirPath)
+
+	databaseURL := fmt.Sprintf(
+		"file://%s?_busy_timeout=5000&_foreign_keys=on&_journal_mode=WAL",
+		path.Join(dirPath, "database.db"),
+	)
+	br, err := NewBackupRestorer(ts.URL, databaseURL)
+	require.NoError(t, err)
+	err = br.Restore()
+	require.NoError(t, err)
+
+	db, err := sql.Open("sqlite3", databaseURL)
+	require.NoError(t, err)
+
+	var a int
+	err = db.QueryRow("SELECT a FROM a LIMIT 1").Scan(&a)
+	require.NoError(t, err)
+	require.Equal(t, 1, a)
+
+	var address string
+	err = db.QueryRow("SELECT address FROM system_pending_tx").Scan(&address)
+	require.NoError(t, err)
+	require.Equal(t, "existing address", address)
+
+	var nodeID string
+	err = db.QueryRow("SELECT id FROM system_id").Scan(&nodeID)
+	require.NoError(t, err)
+	require.Equal(t, "existing node id", nodeID)
+}
+
+func createExistingDatabase(t *testing.T, dir string) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", path.Join(dir, "database.db"))
+	require.NoError(t, err)
+
+	_, err = db.Exec("CREATE TABLE IF NOT EXISTS system_id (id TEXT NOT NULL, PRIMARY KEY(id));")
+	require.NoError(t, err)
+
+	_, err = db.Exec("INSERT INTO system_id VALUES ('existing node id');")
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE system_pending_tx (
+			chain_id INTEGER NOT NULL,
+			address TEXT NOT NULL,
+			hash TEXT NOT NULL,
+			nonce INTEGER NOT NULL,
+			bump_price_count INTEGER NOT NULL DEFAULT 0,
+			created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+			updated_at INTEGER,
+			PRIMARY KEY(chain_id, address, nonce)
+		);
+	`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO system_pending_tx
+		VALUES (1, 'existing address', 'hash', 1, 0, strftime('%s', 'now'), strftime('%s', 'now'));
+	`)
+	require.NoError(t, err)
+
+	require.NoError(t, db.Close())
 }


### PR DESCRIPTION
# Summary

A small improvement in the backup restoration process to consider that a database could already exist and contain local information such as node id and pending transactions

# Context

The backup restorer was deleting the node id and pending txs from the backup database. But that turns out to be a bad idea. The node that is bootstrapping from a backup file may have pending txs in its local databases, and it already has a node id. Deleting those means that we lose track of the pending txs, and the node is forced to generate a new node id, which is not ideal.

# Implementation overview

- We check if a database already exists
- If a database already exists, rename it to another name
- Create a new database that is a copy of the backup
- Delete information from `system_pending_tx` and `system_id` tables
- Copy information of `system_pending_txs` and `system_id` tables from the existing renamed database to the new database
- Delete existing renamed database

# Implementation details and review orientation

na

# Checklist


- [x]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [x]  Are changes covered by existing tests, or were new tests included?
- [x]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [x]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
