### PR TITLE
Fix #378 allow config dir path as command flag

### DIFF
--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -18,6 +18,7 @@ import (
 var configFilename = "config.json"
 
 type config struct {
+	Dir string
 	HTTP struct {
 		Port string `default:"8080"` // HTTP port (e.g. 8080)
 

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -18,7 +18,7 @@ import (
 var configFilename = "config.json"
 
 type config struct {
-	Dir string
+	Dir  string
 	HTTP struct {
 		Port string `default:"8080"` // HTTP port (e.g. 8080)
 

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -18,7 +18,7 @@ import (
 var configFilename = "config.json"
 
 type config struct {
-	Dir  string
+	Dir  string // This will default to "", NOT the default dir value set via the flag package
 	HTTP struct {
 		Port string `default:"8080"` // HTTP port (e.g. 8080)
 


### PR DESCRIPTION
TL;DR; uconfig enforces that all flags be defined in the config struct
See the discussion in #378 for more detail.