### PR TITLE
main: refactor wirings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,6 @@ linters-settings:
 
 linters:
   enable:
-    - revive
     - misspell
     - bodyclose
     - unconvert

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -18,46 +18,59 @@ import (
 var configFilename = "config.json"
 
 type config struct {
-	Dir  string // This will default to "", NOT the default dir value set via the flag package
-	HTTP struct {
-		Port string `default:"8080"` // HTTP port (e.g. 8080)
+	Dir                string // This will default to "", NOT the default dir value set via the flag package
+	BootstrapBackupURL string `default:"" env:"BOOTSTRAP_BACKUP_URL"`
 
-		TLSCert string `default:""`
-		TLSKey  string `default:""`
+	HTTP    HTTPConfig
+	Gateway GatewayConfig
 
-		RateLimInterval       string `default:"1s"`
-		MaxRequestPerInterval uint64 `default:"10"`
-	}
-	Gateway struct {
-		ExternalURIPrefix   string `default:"https://testnet.tableland.network"`
-		MetadataRendererURI string `default:""`
-	}
 	TableConstraints TableConstraints
 	QueryConstraints QueryConstraints
-	Metrics          struct {
+
+	Metrics struct {
 		Port string `default:"9090"`
 	}
 	Log struct {
 		Human bool `default:"false"`
 		Debug bool `default:"false"`
 	}
-	Chains    []ChainConfig
 	Analytics struct {
 		FetchExtraBlockInfo bool `default:"false"`
 	}
-	Backup struct {
-		Enabled           bool   `default:"true"`
-		Dir               string `default:"backups"` // relative to dir path config (e.g. ${HOME}/.tableland/backups )
-		Frequency         int    `default:"120"`     // in minutes
-		EnableVacuum      bool   `default:"true"`
-		EnableCompression bool   `default:"true"`
-		Pruning           struct {
-			Enabled   bool `default:"true"`
-			KeepFiles int  `default:"5"` // number of files to keep
-		}
-	}
+	Backup             BackupConfig
 	TelemetryPublisher TelemetryPublisherConfig
-	BootstrapBackupURL string `default:"" env:"BOOTSTRAP_BACKUP_URL"`
+
+	Chains []ChainConfig
+}
+
+// HTTPConfig contains configuration for the HTTP server serving APIs.
+type HTTPConfig struct {
+	Port string `default:"8080"` // HTTP port (e.g. 8080)
+
+	TLSCert string `default:""`
+	TLSKey  string `default:""`
+
+	RateLimInterval       string `default:"1s"`
+	MaxRequestPerInterval uint64 `default:"10"`
+}
+
+// GatewayConfig contains configuration for the Gateway.
+type GatewayConfig struct {
+	ExternalURIPrefix   string `default:"https://testnet.tableland.network"`
+	MetadataRendererURI string `default:""`
+}
+
+// BackupConfig contains configuration for automatic database backups.
+type BackupConfig struct {
+	Enabled           bool   `default:"true"`
+	Dir               string `default:"backups"` // relative to dir path config (e.g. ${HOME}/.tableland/backups )
+	Frequency         int    `default:"120"`     // in minutes
+	EnableVacuum      bool   `default:"true"`
+	EnableCompression bool   `default:"true"`
+	Pruning           struct {
+		Enabled   bool `default:"true"`
+		KeepFiles int  `default:"5"` // number of files to keep
+	}
 }
 
 // TelemetryPublisherConfig contains configuration attributes for the telemetry module.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -47,241 +47,106 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-type moduleClose func(ctx context.Context) error
+type moduleCloser func(ctx context.Context) error
+
+var closerNoop = func(context.Context) error { return nil }
 
 func main() {
 	config, dirPath := setupConfig()
+
+	// Logging.
 	logging.SetupLogger(buildinfo.GitCommit, config.Log.Debug, config.Log.Human)
 
-	// Validator instrumentation configuration.
+	// Instrumentation.
 	if err := metrics.SetupInstrumentation(":"+config.Metrics.Port, "tableland:api"); err != nil {
-		log.Fatal().
-			Err(err).
-			Str("port", config.Metrics.Port).
-			Msg("could not setup instrumentation")
+		log.Fatal().Err(err).Str("port", config.Metrics.Port).Msg("could not setup instrumentation")
 	}
 
+	// Database URL.
 	databaseURL := fmt.Sprintf(
 		"file://%s?_busy_timeout=5000&_foreign_keys=on&_journal_mode=WAL",
 		path.Join(dirPath, "database.db"),
 	)
 
+	// Restore provided backup (if configured).
 	if config.BootstrapBackupURL != "" {
-		restorer, err := restorer.NewBackupRestorer(config.BootstrapBackupURL, databaseURL)
-		if err != nil {
-			log.Fatal().
-				Err(err).
-				Msg("creating restorer")
+		if err := restoreBackup(databaseURL, config.BootstrapBackupURL); err != nil {
+			log.Fatal().Err(err).Msg("restoring backup")
 		}
-
-		log.Info().Msg("starting backup restore")
-		elapsedTime := time.Now()
-		if err := restorer.Restore(); err != nil {
-			log.Fatal().
-				Err(err).
-				Msg("backup restoration failed")
-		}
-		log.Info().Float64("elapsed_time_seconds", time.Since(elapsedTime).Seconds()).Msg("backup restore finished")
 	}
 
-	parserOpts := []parsing.Option{
-		parsing.WithMaxReadQuerySize(config.QueryConstraints.MaxReadQuerySize),
-		parsing.WithMaxWriteQuerySize(config.QueryConstraints.MaxWriteQuerySize),
-	}
-
-	parser, err := parserimpl.New([]string{
-		"sqlite_",
-		systemimpl.SystemTablesPrefix,
-		systemimpl.RegistryTableName,
-	}, parserOpts...)
+	// Parser.
+	parser, err := createParser(config.QueryConstraints)
 	if err != nil {
-		log.Fatal().Err(err).Msg("new parser")
+		log.Fatal().Err(err).Msg("creating parser")
 	}
 
-	parser, err = parserimpl.NewInstrumentedSQLValidator(parser)
+	// Chain stacks.
+	chainStacks, closeChainStacks, err := createChainStacks(
+		databaseURL,
+		parser,
+		config.Chains,
+		config.TableConstraints,
+		config.Analytics.FetchExtraBlockInfo)
 	if err != nil {
-		log.Fatal().Err(err).Msg("instrumenting sql validator")
+		log.Fatal().Err(err).Msg("creating chains stack")
 	}
 
-	executorsDB, err := otelsql.Open("sqlite3", databaseURL)
-	if err != nil {
-		log.Fatal().Err(err).Msg("creating executors db")
-	}
-	executorsDB.SetMaxOpenConns(1)
-	attrs := append([]attribute.KeyValue{attribute.String("name", "executors")}, metrics.BaseAttrs...)
-	if err := otelsql.RegisterDBStatsMetrics(
-		executorsDB,
-		otelsql.WithAttributes(attrs...)); err != nil {
-		log.Fatal().Err(err).Msg("registering executors db stats")
-	}
-
-	chainStacks := map[tableland.ChainID]chains.ChainStack{}
-	for _, chainCfg := range config.Chains {
-		if _, ok := chainStacks[chainCfg.ChainID]; ok {
-			log.Fatal().Int64("chain_id", int64(chainCfg.ChainID)).Msg("chain id configuration is duplicated")
-		}
-		chainStack, err := createChainIDStack(
-			chainCfg,
-			databaseURL,
-			executorsDB,
-			parser,
-			config.TableConstraints,
-			config.Analytics.FetchExtraBlockInfo)
-		if err != nil {
-			log.Fatal().Int64("chain_id", int64(chainCfg.ChainID)).Err(err).Msg("spinning up chain stack")
-		}
-		chainStacks[chainCfg.ChainID] = chainStack
-	}
-
+	// User store.
 	userStore, err := user.New(databaseURL)
 	if err != nil {
 		log.Fatal().Err(err).Msg("creating user store")
 	}
 
-	rateLimInterval, err := time.ParseDuration(config.HTTP.RateLimInterval)
+	// HTTP API server.
+	closeHTTPServer, err := createHTTPServer(config.HTTP, config.Gateway, parser, userStore, chainStacks)
 	if err != nil {
-		log.Fatal().Err(err).Msg("parsing http rate lim interval")
+		log.Fatal().Err(err).Msg("creating HTTP server")
 	}
 
-	router := router.ConfiguredRouter(
-		config.Gateway.ExternalURIPrefix,
-		config.Gateway.MetadataRendererURI,
-		config.HTTP.MaxRequestPerInterval,
-		rateLimInterval,
-		parser,
-		userStore,
-		chainStacks,
-	)
-
-	server := &http.Server{
-		Addr:         ":" + config.HTTP.Port,
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 20 * time.Second,
-		IdleTimeout:  120 * time.Second,
-		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
-		Handler:      router.Handler(),
-	}
-
-	go func() {
-		if config.HTTP.TLSCert != "" {
-			tlsCert, err := base64.StdEncoding.DecodeString(config.HTTP.TLSCert)
-			if err != nil {
-				log.Fatal().
-					Err(err).
-					Msg("could not base64 decode tls cert")
-			}
-			tlsKey, err := base64.StdEncoding.DecodeString(config.HTTP.TLSKey)
-			if err != nil {
-				log.Fatal().
-					Err(err).
-					Msg("could not base64 decode tls cert")
-			}
-
-			cert, err := tls.X509KeyPair(tlsCert, tlsKey)
-			if err != nil {
-				log.Fatal().
-					Err(err).
-					Msg("parsing tls certificate")
-			}
-			server.TLSConfig = &tls.Config{
-				Certificates: []tls.Certificate{cert},
-				MinVersion:   tls.VersionTLS13,
-				CipherSuites: []uint16{
-					tls.TLS_AES_128_GCM_SHA256,
-					tls.TLS_AES_256_GCM_SHA384,
-					tls.TLS_CHACHA20_POLY1305_SHA256,
-				},
-			}
-
-			server.Addr = ":443"
-			if err := server.ListenAndServeTLS("", ""); err != nil {
-				if err == http.ErrServerClosed {
-					log.Info().Msg("https serve gracefully closed")
-					return
-				}
-				log.Fatal().
-					Err(err).
-					Msg("could not start https server")
-			}
-		} else {
-			if err := server.ListenAndServe(); err != nil {
-				if err == http.ErrServerClosed {
-					log.Info().Msg("http server gracefully closed")
-					return
-				}
-				log.Fatal().
-					Err(err).
-					Str("port", config.HTTP.Port).
-					Msg("could not start http server")
-			}
-		}
-	}()
-
-	var backupScheduler *backup.Scheduler
+	// Backuper.
+	closeBackupScheduler := closerNoop
 	if config.Backup.Enabled {
-		backupScheduler, err = backup.NewScheduler(config.Backup.Frequency, backup.BackuperOptions{
-			SourcePath: path.Join(dirPath, "database.db"),
-			BackupDir:  path.Join(dirPath, config.Backup.Dir),
-			Opts: []backup.Option{
-				backup.WithCompression(config.Backup.EnableCompression),
-				backup.WithVacuum(config.Backup.EnableVacuum),
-				backup.WithPruning(config.Backup.Pruning.Enabled, config.Backup.Pruning.KeepFiles),
-			},
-		}, false)
+		closeBackupScheduler, err = createBackuper(dirPath, config.Backup)
 		if err != nil {
-			log.Fatal().
-				Err(err).
-				Msg("could not instantiate backup scheduler")
+			log.Fatal().Err(err).Msg("creating backuper")
 		}
-		go backupScheduler.Run()
 	}
 
-	nodeID, err := chainStacks[config.Chains[0].ChainID].Store.GetID(context.Background())
-	if err != nil {
-		log.Fatal().Err(err).Msg("getting node id")
-	}
-
-	log.Info().Str("node_id", nodeID).Msg("node info")
-
-	closeTelemetryModule, err := configureTelemetry(nodeID, dirPath, chainStacks, config.TelemetryPublisher)
+	// Telemetry
+	closeTelemetryModule, err := configureTelemetry(dirPath, chainStacks, config.TelemetryPublisher)
 	if err != nil {
 		log.Fatal().Err(err).Msg("configuring telemetry")
 	}
 
 	cli.HandleInterrupt(func() {
-		var wg sync.WaitGroup
-		wg.Add(len(chainStacks))
-		for chainID, stack := range chainStacks {
-			go func(chainID tableland.ChainID, stack chains.ChainStack) {
-				defer wg.Done()
-
-				ctx, cls := context.WithTimeout(context.Background(), time.Second*15)
-				defer cls()
-				if err := stack.Close(ctx); err != nil {
-					log.Error().Err(err).Int64("chain_id", int64(chainID)).Msg("finalizing chain stack")
-				}
-			}(chainID, stack)
-		}
-		wg.Wait()
-
+		// Close HTTP server.
 		ctx, cls := context.WithTimeout(context.Background(), time.Second*10)
 		defer cls()
-		if err := server.Shutdown(ctx); err != nil {
+		if err := closeHTTPServer(ctx); err != nil {
 			log.Error().Err(err).Msg("shutting down http server")
 		}
 
-		if config.Backup.Enabled {
-			backupScheduler.Shutdown()
+		// Close chains syncing.
+		ctx, cls = context.WithTimeout(context.Background(), time.Second*20)
+		defer cls()
+		if err := closeChainStacks(ctx); err != nil {
+			log.Error().Err(err).Msg("closing chains stack")
 		}
 
+		// Close backuper.
+		ctx, cls = context.WithTimeout(context.Background(), time.Second*20)
+		defer cls()
+		if err := closeBackupScheduler(ctx); err != nil {
+			log.Error().Err(err).Msg("closing backuper")
+		}
+
+		// Close user store.
 		if err := userStore.Close(); err != nil {
 			log.Error().Err(err).Msg("closing user store")
 		}
 
-		if err := executorsDB.Close(); err != nil {
-			log.Error().Err(err).Msg("closing executors db")
-		}
-
+		// Close telemetry.
 		if err := closeTelemetryModule(ctx); err != nil {
 			log.Error().Err(err).Msg("closing telemetry module")
 		}
@@ -418,11 +283,21 @@ func createChainIDStack(
 }
 
 func configureTelemetry(
-	nodeID string,
 	dirPath string,
 	chainStacks map[tableland.ChainID]chains.ChainStack,
 	config TelemetryPublisherConfig,
-) (moduleClose, error) {
+) (moduleCloser, error) {
+	var nodeID string
+	var err error
+	for chainID := range chainStacks {
+		nodeID, err = chainStacks[chainID].Store.GetID(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("get node ID: %s", err)
+		}
+		log.Info().Str("node_id", nodeID).Msg("node info")
+		break
+	}
+
 	// Wiring
 	metricsDatabaseURL := fmt.Sprintf(
 		"file://%s?_busy_timeout=5000&_foreign_keys=on&_journal_mode=WAL",
@@ -489,4 +364,216 @@ func configureTelemetry(
 
 		return nil
 	}, nil
+}
+
+func restoreBackup(databaseURL string, backupURL string) error {
+	restorer, err := restorer.NewBackupRestorer(backupURL, databaseURL)
+	if err != nil {
+		return fmt.Errorf("creating restorer: %s", err)
+	}
+
+	log.Info().Msg("starting backup restore")
+	elapsedTime := time.Now()
+	if err := restorer.Restore(); err != nil {
+		return fmt.Errorf("backup restoration failed: %s", err)
+	}
+	log.Info().Float64("elapsed_time_seconds", time.Since(elapsedTime).Seconds()).Msg("backup restore finished")
+	return nil
+}
+
+func createParser(queryConstraints QueryConstraints) (parsing.SQLValidator, error) {
+	parserOpts := []parsing.Option{
+		parsing.WithMaxReadQuerySize(queryConstraints.MaxReadQuerySize),
+		parsing.WithMaxWriteQuerySize(queryConstraints.MaxWriteQuerySize),
+	}
+
+	parser, err := parserimpl.New([]string{
+		"sqlite_",
+		systemimpl.SystemTablesPrefix,
+		systemimpl.RegistryTableName,
+	}, parserOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("new parser: %s", err)
+	}
+
+	parser, err = parserimpl.NewInstrumentedSQLValidator(parser)
+	if err != nil {
+		return nil, fmt.Errorf("instrumenting parser: %s", err)
+	}
+
+	return parser, nil
+}
+
+func createChainStacks(
+	databaseURL string,
+	parser parsing.SQLValidator,
+	chainsConfig []ChainConfig,
+	tableConstraintsConfig TableConstraints,
+	fetchExtraBlockInfo bool,
+) (map[tableland.ChainID]chains.ChainStack, moduleCloser, error) {
+	executorsDB, err := otelsql.Open("sqlite3", databaseURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening database: %s", err)
+	}
+	executorsDB.SetMaxOpenConns(1)
+	attrs := append([]attribute.KeyValue{attribute.String("name", "executors")}, metrics.BaseAttrs...)
+	if err := otelsql.RegisterDBStatsMetrics(
+		executorsDB,
+		otelsql.WithAttributes(attrs...)); err != nil {
+		return nil, nil, fmt.Errorf("registering executors db stats: %s", err)
+	}
+
+	chainStacks := map[tableland.ChainID]chains.ChainStack{}
+	for _, chainCfg := range chainsConfig {
+		if _, ok := chainStacks[chainCfg.ChainID]; ok {
+			return nil, nil, fmt.Errorf("duplicated chain id configuration for chain_id=%d", chainCfg.ChainID)
+		}
+		chainStack, err := createChainIDStack(
+			chainCfg,
+			databaseURL,
+			executorsDB,
+			parser,
+			tableConstraintsConfig,
+			fetchExtraBlockInfo)
+		if err != nil {
+			return nil, nil, fmt.Errorf("creating chain_id=%d stack: %s", chainCfg.ChainID, err)
+		}
+		chainStacks[chainCfg.ChainID] = chainStack
+	}
+
+	close := func(ctx context.Context) error {
+		// Close chains syncing.
+		var wg sync.WaitGroup
+		wg.Add(len(chainStacks))
+		for chainID, stack := range chainStacks {
+			go func(chainID tableland.ChainID, stack chains.ChainStack) {
+				defer wg.Done()
+
+				ctx, cls := context.WithTimeout(context.Background(), time.Second*15)
+				defer cls()
+				if err := stack.Close(ctx); err != nil {
+					log.Error().Err(err).Int64("chain_id", int64(chainID)).Msg("finalizing chain stack")
+				}
+			}(chainID, stack)
+		}
+		wg.Wait()
+
+		// Close Executor DB.
+		if err := executorsDB.Close(); err != nil {
+			log.Error().Err(err).Msg("closing executors db")
+		}
+		return nil
+	}
+
+	return chainStacks, close, nil
+}
+
+func createHTTPServer(
+	httpConfig HTTPConfig,
+	gatewayConfig GatewayConfig,
+	parser parsing.SQLValidator,
+	userStore *user.UserStore,
+	chainStacks map[tableland.ChainID]chains.ChainStack,
+) (moduleCloser, error) {
+	rateLimInterval, err := time.ParseDuration(httpConfig.RateLimInterval)
+	if err != nil {
+		return nil, fmt.Errorf("parsing http ratelimiter interval: %s", err)
+	}
+
+	router := router.ConfiguredRouter(
+		gatewayConfig.ExternalURIPrefix,
+		gatewayConfig.MetadataRendererURI,
+		httpConfig.MaxRequestPerInterval,
+		rateLimInterval,
+		parser,
+		userStore,
+		chainStacks,
+	)
+
+	server := &http.Server{
+		Addr:         ":" + httpConfig.Port,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 20 * time.Second,
+		IdleTimeout:  120 * time.Second,
+		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
+		Handler:      router.Handler(),
+	}
+
+	if httpConfig.TLSCert != "" {
+		tlsCert, err := base64.StdEncoding.DecodeString(httpConfig.TLSCert)
+		if err != nil {
+			return nil, fmt.Errorf("base64 decoding TLS certificate: %s", err)
+		}
+		tlsKey, err := base64.StdEncoding.DecodeString(httpConfig.TLSKey)
+		if err != nil {
+			return nil, fmt.Errorf("base64 decoding TLS key: %s", err)
+		}
+
+		cert, err := tls.X509KeyPair(tlsCert, tlsKey)
+		if err != nil {
+			return nil, fmt.Errorf("parsing TLS certificate: %s", err)
+		}
+		server.TLSConfig = &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS13,
+			CipherSuites: []uint16{
+				tls.TLS_AES_128_GCM_SHA256,
+				tls.TLS_AES_256_GCM_SHA384,
+				tls.TLS_CHACHA20_POLY1305_SHA256,
+			},
+		}
+		server.Addr = ":443"
+	}
+
+	go func() {
+		if httpConfig.TLSCert != "" {
+			if err := server.ListenAndServeTLS("", ""); err != nil {
+				if err == http.ErrServerClosed {
+					log.Info().Msg("https serve gracefully closed")
+					return
+				}
+				log.Fatal().Err(err).Str("port", httpConfig.Port).Msg("couldn't not start HTTPS server")
+			}
+		} else {
+			if err := server.ListenAndServe(); err != nil {
+				if err == http.ErrServerClosed {
+					log.Info().Msg("http server gracefully closed")
+					return
+				}
+				log.Fatal().Err(err).Str("port", httpConfig.Port).Msg("couldn't start HTTP server")
+			}
+		}
+	}()
+
+	close := func(ctx context.Context) error {
+		if err := server.Shutdown(ctx); err != nil {
+			log.Error().Err(err).Msg("closing HTTP server")
+		}
+		return nil
+	}
+
+	return close, nil
+}
+
+func createBackuper(dirPath string, config BackupConfig) (moduleCloser, error) {
+	backupScheduler, err := backup.NewScheduler(config.Frequency, backup.BackuperOptions{
+		SourcePath: path.Join(dirPath, "database.db"),
+		BackupDir:  path.Join(dirPath, config.Dir),
+		Opts: []backup.Option{
+			backup.WithCompression(config.EnableCompression),
+			backup.WithVacuum(config.EnableVacuum),
+			backup.WithPruning(config.Pruning.Enabled, config.Pruning.KeepFiles),
+		},
+	}, false)
+	if err != nil {
+		return nil, fmt.Errorf("creating backup scheduler: %s", err)
+	}
+	go backupScheduler.Run()
+
+	close := func(ctx context.Context) error {
+		backupScheduler.Shutdown()
+		return nil
+	}
+
+	return close, nil
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -275,7 +275,7 @@ func createChainIDStack(
 			tracker.Close()
 			conn.Close()
 			if err := systemStore.Close(); err != nil {
-				log.Error().Int64("chain_id", int64(config.ChainID)).Err(err).Msg("closing system store")
+				return fmt.Errorf("closing system store for chain_id %d: %s", config.ChainID, err)
 			}
 			return nil
 		},
@@ -460,7 +460,7 @@ func createChainStacks(
 
 		// Close Executor DB.
 		if err := executorsDB.Close(); err != nil {
-			log.Error().Err(err).Msg("closing executors db")
+			return fmt.Errorf("closing executors db: %s", err)
 		}
 		return nil
 	}
@@ -547,7 +547,7 @@ func createHTTPServer(
 
 	close := func(ctx context.Context) error {
 		if err := server.Shutdown(ctx); err != nil {
-			log.Error().Err(err).Msg("closing HTTP server")
+			return fmt.Errorf("closing HTTP server")
 		}
 		return nil
 	}


### PR DESCRIPTION
# Summary

This PR does a general refactor in `main.go` to organize our wires better. The main goal is to have a `func main()` that's more understandable.

# Context

Closes #302 

# Implementation overview

The `main()` function is now more high-level, always calling `create***()` functions that will create modules. These methods usually return a `close***` variable, a `moduleCloser` function to be used when Ctrl+C is received.

To clarify things, I've extracted anonymous structs used in `config.go` to be non-anonymous.

# Implementation details and review orientation

NA

