### PR TITLE
Collects read query metrics 

### DIFF
--- a/internal/router/controllers/user.go
+++ b/internal/router/controllers/user.go
@@ -350,7 +350,7 @@ func CollectReadQueryMetric(ctx context.Context, statement string, config format
 			Output:  string(config.Output),
 		}
 
-		metric := &ReadQueryMetricData{
+		metric := &readQueryMetricData{
 			ipAddress:     ipAddress,
 			sqlStatement:  statement,
 			formatOptions: formatOptions,
@@ -364,16 +364,16 @@ func CollectReadQueryMetric(ctx context.Context, statement string, config format
 	}
 }
 
-type ReadQueryMetricData struct {
+type readQueryMetricData struct {
 	ipAddress     string
 	sqlStatement  string
 	formatOptions telemetry.ReadQueryFormatOptions
 	tookMilli     int64
 }
 
-func (m *ReadQueryMetricData) IPAddress() string    { return m.ipAddress }
-func (m *ReadQueryMetricData) SQLStatement() string { return m.sqlStatement }
-func (m *ReadQueryMetricData) FormatOptions() telemetry.ReadQueryFormatOptions {
+func (m *readQueryMetricData) IPAddress() string    { return m.ipAddress }
+func (m *readQueryMetricData) SQLStatement() string { return m.sqlStatement }
+func (m *readQueryMetricData) FormatOptions() telemetry.ReadQueryFormatOptions {
 	return m.formatOptions
 }
-func (m *ReadQueryMetricData) TookMilli() int64 { return m.tookMilli }
+func (m *readQueryMetricData) TookMilli() int64 { return m.tookMilli }

--- a/internal/router/middlewares/contextkeys.go
+++ b/internal/router/middlewares/contextkeys.go
@@ -8,4 +8,6 @@ const (
 	ContextKeyAddress ContextKey = iota
 	// ContextKeyChainID is used to store the chain id of the client for the incoming request.
 	ContextKeyChainID ContextKey = iota
+	// ContextIPAddress is used to store the ip address of the client for the incoming request.
+	ContextIPAddress ContextKey = iota
 )

--- a/internal/router/middlewares/logging.go
+++ b/internal/router/middlewares/logging.go
@@ -1,6 +1,7 @@
 package middlewares
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/rs/zerolog/log"
@@ -9,17 +10,20 @@ import (
 // WithLogging logs requests and responses that contain useful information.
 func WithLogging(h http.Handler) http.Handler {
 	handler := func(rw http.ResponseWriter, r *http.Request) {
+		clientIP, err := extractClientIP(r)
+		if err != nil {
+			log.Warn().Err(err).Msg("can't extract client ip")
+			clientIP = "none"
+		}
+
+		r = r.WithContext(context.WithValue(r.Context(), ContextIPAddress, clientIP))
+
 		loggedRW := &responseWriterLogger{
 			ResponseWriter: rw,
 		}
 		h.ServeHTTP(loggedRW, r)
 
 		if loggedRW.statusCode != http.StatusOK {
-			clientIP, err := extractClientIP(r)
-			if err != nil {
-				log.Warn().Err(err).Msg("can't extract client ip")
-				clientIP = "none"
-			}
 			log.Ctx(r.Context()).
 				Warn().
 				Int("statusCode", loggedRW.statusCode).

--- a/internal/router/middlewares/logging.go
+++ b/internal/router/middlewares/logging.go
@@ -13,7 +13,7 @@ func WithLogging(h http.Handler) http.Handler {
 		clientIP, err := extractClientIP(r)
 		if err != nil {
 			log.Warn().Err(err).Msg("can't extract client ip")
-			clientIP = "none"
+			clientIP = ""
 		}
 
 		r = r.WithContext(context.WithValue(r.Context(), ContextIPAddress, clientIP))

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -95,19 +95,22 @@ type ChainStacksMetric struct {
 type ReadQuery interface {
 	IPAddress() string
 	SQLStatement() string
+	FormatOptions() ReadQueryFormatOptions
+	TookMilli() int64
+}
 
-	Unwrap() bool
-	Extract() bool
-	Output() string
+type ReadQueryFormatOptions struct {
+	Extract bool   `json:"extract"`
+	Unwrap  bool   `json:"unwrap"`
+	Output  string `json:"output"`
 }
 
 // ReadQueryMetric contains information about a read query.
 type ReadQueryMetric struct {
 	Version int `json:"version"`
 
-	IPAddress    string `json:"ip_address"`
-	SQLStatement string `json:"sql_statement"`
-	Unwrap       bool   `json:"unwrap"`
-	Extract      bool   `json:"extract"`
-	Output       string `json:"output"`
+	IPAddress     string                 `json:"ip_address"`
+	SQLStatement  string                 `json:"sql_statement"`
+	FormatOptions ReadQueryFormatOptions `json:"format_options"`
+	TookMilli     int64                  `json:"took_milli"`
 }

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -18,6 +18,8 @@ const (
 	GitSummaryType
 	// ChainStacksSummaryType is the type for the ChainStacksMetric.
 	ChainStacksSummaryType
+	// ReadQueryType is the type for the ReadQueryMetric.
+	ReadQueryType
 )
 
 // Metric defines a metric.
@@ -87,4 +89,25 @@ type ChainStacksMetric struct {
 	Version int `json:"version"`
 
 	LastProcessedBlockNumbers map[tableland.ChainID]int64 `json:"last_processed_block_number"`
+}
+
+// ReadQuery defines how data is accessed to create a ReadQueryMetric.
+type ReadQuery interface {
+	IPAddress() string
+	SQLStatement() string
+
+	Unwrap() bool
+	Extract() bool
+	Output() string
+}
+
+// ReadQueryMetric contains information about a read query.
+type ReadQueryMetric struct {
+	Version int `json:"version"`
+
+	IPAddress    string `json:"ip_address"`
+	SQLStatement string `json:"sql_statement"`
+	Unwrap       bool   `json:"unwrap"`
+	Extract      bool   `json:"extract"`
+	Output       string `json:"output"`
 }

--- a/pkg/telemetry/publisher/publisher.go
+++ b/pkg/telemetry/publisher/publisher.go
@@ -93,7 +93,7 @@ func (p *Publisher) publish(ctx context.Context) error {
 	}
 
 	sevenDays := 24 * 7 * time.Hour
-	if err := p.store.DeleteOlderThan(ctx, sevenDays); err != nil {
+	if err := p.store.DeletePublishedOlderThan(ctx, sevenDays); err != nil {
 		return fmt.Errorf("delete older than: %s", err)
 	}
 
@@ -104,7 +104,7 @@ func (p *Publisher) publish(ctx context.Context) error {
 type MetricsStore interface {
 	FetchMetrics(context.Context, bool, int) ([]telemetry.Metric, error)
 	MarkAsPublished(context.Context, []int64) error
-	DeleteOlderThan(context.Context, time.Duration) error
+	DeletePublishedOlderThan(context.Context, time.Duration) error
 }
 
 // MetricsExporter defines the API for exporting metrics.

--- a/pkg/telemetry/publisher/publisher.go
+++ b/pkg/telemetry/publisher/publisher.go
@@ -94,7 +94,7 @@ func (p *Publisher) publish(ctx context.Context) error {
 
 	sevenDays := 24 * 7 * time.Hour
 	if err := p.store.DeleteOlderThan(ctx, sevenDays); err != nil {
-		return fmt.Errorf("mark as published: %s", err)
+		return fmt.Errorf("delete older than: %s", err)
 	}
 
 	return nil

--- a/pkg/telemetry/publisher/publisher.go
+++ b/pkg/telemetry/publisher/publisher.go
@@ -70,7 +70,7 @@ func (p *Publisher) Close() {
 }
 
 func (p *Publisher) publish(ctx context.Context) error {
-	metrics, err := p.store.FetchUnpublishedMetrics(ctx, p.fetchAmount)
+	metrics, err := p.store.FetchMetrics(ctx, false, p.fetchAmount)
 	if err != nil {
 		return fmt.Errorf("fetch unpublished metrics: %s", err)
 	}
@@ -92,13 +92,19 @@ func (p *Publisher) publish(ctx context.Context) error {
 		return fmt.Errorf("mark as published: %s", err)
 	}
 
+	sevenDays := 24 * 7 * time.Hour
+	if err := p.store.DeleteOlderThan(ctx, sevenDays); err != nil {
+		return fmt.Errorf("mark as published: %s", err)
+	}
+
 	return nil
 }
 
 // MetricsStore defines the API for fetching metrics and marking them as published.
 type MetricsStore interface {
-	FetchUnpublishedMetrics(context.Context, int) ([]telemetry.Metric, error)
+	FetchMetrics(context.Context, bool, int) ([]telemetry.Metric, error)
 	MarkAsPublished(context.Context, []int64) error
+	DeleteOlderThan(context.Context, time.Duration) error
 }
 
 // MetricsExporter defines the API for exporting metrics.

--- a/pkg/telemetry/publisher/publisher_test.go
+++ b/pkg/telemetry/publisher/publisher_test.go
@@ -29,15 +29,16 @@ func TestPublisher(t *testing.T) {
 	p.Start()
 
 	require.Eventually(t, func() bool {
-		return store.Len() == 0
+		return store.Len() == 0 && store.deleteOlderThanCalled
 	}, 5*time.Second, time.Second)
 
 	p.Close()
 }
 
 type store struct {
-	mu        sync.Mutex
-	unplished []telemetry.Metric
+	mu                    sync.Mutex
+	unplished             []telemetry.Metric
+	deleteOlderThanCalled bool
 }
 
 func newStore() *store {
@@ -63,7 +64,7 @@ func (s *store) Len() int {
 	return len(s.unplished)
 }
 
-func (s *store) FetchUnpublishedMetrics(_ context.Context, _ int) ([]telemetry.Metric, error) {
+func (s *store) FetchMetrics(_ context.Context, _ bool, _ int) ([]telemetry.Metric, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.unplished, nil
@@ -73,5 +74,12 @@ func (s *store) MarkAsPublished(_ context.Context, _ []int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.unplished = []telemetry.Metric{}
+	return nil
+}
+
+func (s *store) DeleteOlderThan(context.Context, time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deleteOlderThanCalled = true
 	return nil
 }

--- a/pkg/telemetry/publisher/publisher_test.go
+++ b/pkg/telemetry/publisher/publisher_test.go
@@ -77,7 +77,7 @@ func (s *store) MarkAsPublished(_ context.Context, _ []int64) error {
 	return nil
 }
 
-func (s *store) DeleteOlderThan(context.Context, time.Duration) error {
+func (s *store) DeletePublishedOlderThan(context.Context, time.Duration) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.deleteOlderThanCalled = true

--- a/pkg/telemetry/storage/db.go
+++ b/pkg/telemetry/storage/db.go
@@ -179,14 +179,14 @@ func (db *TelemetryDatabase) MarkAsPublished(ctx context.Context, rowids []int64
 	return nil
 }
 
-// DeleteOlderThan deletes metrics other than provided duration.
-func (db *TelemetryDatabase) DeleteOlderThan(ctx context.Context, duration time.Duration) error {
+// DeletePublishedOlderThan deletes metrics other than provided duration.
+func (db *TelemetryDatabase) DeletePublishedOlderThan(ctx context.Context, duration time.Duration) error {
 	if duration < 0 {
 		return nil
 	}
 
 	threshold := time.Now().UTC().Add(-duration).UnixMilli()
-	_, err := db.sqlDB.ExecContext(ctx, "DELETE FROM system_metrics WHERE timestamp < ?1", threshold)
+	_, err := db.sqlDB.ExecContext(ctx, "DELETE FROM system_metrics WHERE timestamp < ?1 and published", threshold)
 	if err != nil {
 		return fmt.Errorf("exec: %s", err)
 	}

--- a/pkg/telemetry/storage/db.go
+++ b/pkg/telemetry/storage/db.go
@@ -76,13 +76,14 @@ func (db *TelemetryDatabase) StoreMetric(ctx context.Context, metric telemetry.M
 	return nil
 }
 
-// FetchUnpublishedMetrics fetches unplished metrics.
-func (db *TelemetryDatabase) FetchUnpublishedMetrics(ctx context.Context, amount int) ([]telemetry.Metric, error) {
+// FetchMetrics fetches unplished metrics.
+func (db *TelemetryDatabase) FetchMetrics(ctx context.Context, published bool, amount int) ([]telemetry.Metric, error) {
 	rows, err := db.sqlDB.QueryContext(ctx,
 		`SELECT rowid, version, timestamp, type, payload, published FROM system_metrics 
-		WHERE published is false 
+		WHERE published is ?1 
 		ORDER BY timestamp
-		LIMIT ?1`,
+		LIMIT ?2`,
+		published,
 		amount,
 	)
 	if err != nil {
@@ -124,6 +125,12 @@ func (db *TelemetryDatabase) FetchUnpublishedMetrics(ctx context.Context, amount
 				return nil, fmt.Errorf("scan rows of system metrics: %s", err)
 			}
 			mType = telemetry.ChainStacksSummaryType
+		case telemetry.ReadQueryType:
+			mPayload = new(telemetry.ReadQueryMetric)
+			if err := json.Unmarshal(payload, mPayload); err != nil {
+				return nil, fmt.Errorf("scan rows of system metrics: %s", err)
+			}
+			mType = telemetry.ReadQueryType
 
 		default:
 			return nil, fmt.Errorf("unknown metric type: %d", typ)
@@ -167,6 +174,21 @@ func (db *TelemetryDatabase) MarkAsPublished(ctx context.Context, rowids []int64
 
 	if rowsAffected != int64(len(rowids)) {
 		return fmt.Errorf("rows affected %d, differs from rowids length %d", rowsAffected, int64(len(rowids)))
+	}
+
+	return nil
+}
+
+// DeleteOlderThan deletes metrics other than provided duration.
+func (db *TelemetryDatabase) DeleteOlderThan(ctx context.Context, duration time.Duration) error {
+	if duration < 0 {
+		return nil
+	}
+
+	threshold := time.Now().UTC().Add(-duration).UnixMilli()
+	_, err := db.sqlDB.ExecContext(ctx, "DELETE FROM system_metrics WHERE timestamp < ?1", threshold)
+	if err != nil {
+		return fmt.Errorf("exec: %s", err)
 	}
 
 	return nil

--- a/pkg/telemetry/storage/db_test.go
+++ b/pkg/telemetry/storage/db_test.go
@@ -175,9 +175,8 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 			payload := metric.Payload.(*telemetry.ReadQueryMetric)
 			require.Equal(t, readQueryMetrics[i].IPAddress(), payload.IPAddress)
 			require.Equal(t, readQueryMetrics[i].SQLStatement(), payload.SQLStatement)
-			require.Equal(t, readQueryMetrics[i].Unwrap(), payload.Unwrap)
-			require.Equal(t, readQueryMetrics[i].Extract(), payload.Extract)
-			require.Equal(t, readQueryMetrics[i].Output(), payload.Output)
+			require.Equal(t, readQueryMetrics[i].FormatOptions(), payload.FormatOptions)
+			require.Equal(t, readQueryMetrics[i].TookMilli(), payload.TookMilli)
 		}
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -265,6 +264,11 @@ type readQuery struct{}
 
 func (rq readQuery) IPAddress() string    { return "0.0.0.0" }
 func (rq readQuery) SQLStatement() string { return "SELECT * FROM foo" }
-func (rq readQuery) Unwrap() bool         { return false }
-func (rq readQuery) Extract() bool        { return true }
-func (rq readQuery) Output() string       { return "objects" }
+func (rq readQuery) FormatOptions() telemetry.ReadQueryFormatOptions {
+	return telemetry.ReadQueryFormatOptions{
+		Extract: true,
+		Unwrap:  false,
+		Output:  "objects",
+	}
+}
+func (rq readQuery) TookMilli() int64 { return 100 }

--- a/pkg/telemetry/storage/db_test.go
+++ b/pkg/telemetry/storage/db_test.go
@@ -202,7 +202,7 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 
 	t.Run("delete old metrics", func(t *testing.T) {
 		// clear store
-		err := s.DeleteOlderThan(context.Background(), 0)
+		err := s.DeletePublishedOlderThan(context.Background(), 0)
 
 		require.NoError(t, err)
 		// Store two metrics. One older than 7 days.

--- a/pkg/telemetry/storage/db_test.go
+++ b/pkg/telemetry/storage/db_test.go
@@ -37,7 +37,7 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 		require.NoError(t, telemetry.Collect(context.Background(), stateHash{}))
 		require.NoError(t, telemetry.Collect(context.Background(), stateHash{}))
 
-		metrics, err := s.FetchUnpublishedMetrics(context.Background(), 10)
+		metrics, err := s.FetchMetrics(context.Background(), false, 10)
 		require.NoError(t, err)
 		require.Len(t, metrics, 2)
 
@@ -64,7 +64,7 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 		p.Start()
 
 		require.Eventually(t, func() bool {
-			metrics, err = s.FetchUnpublishedMetrics(context.Background(), 2)
+			metrics, err = s.FetchMetrics(context.Background(), false, 2)
 			require.NoError(t, err)
 			return len(metrics) == 0
 		}, 5*time.Second, time.Second)
@@ -77,7 +77,7 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 		require.NoError(t, telemetry.Collect(context.Background(), gitSummary{}))
 		require.NoError(t, telemetry.Collect(context.Background(), gitSummary{}))
 
-		metrics, err := s.FetchUnpublishedMetrics(context.Background(), 10)
+		metrics, err := s.FetchMetrics(context.Background(), false, 10)
 		require.NoError(t, err)
 		require.Len(t, metrics, 2)
 
@@ -107,13 +107,14 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 		p.Start()
 
 		require.Eventually(t, func() bool {
-			metrics, err = s.FetchUnpublishedMetrics(context.Background(), 2)
+			metrics, err = s.FetchMetrics(context.Background(), false, 2)
 			require.NoError(t, err)
 			return len(metrics) == 0
 		}, 5*time.Second, time.Second)
 
 		p.Close()
 	})
+
 	t.Run("chains stack summary", func(t *testing.T) {
 		// collect two mocked chainsStackSummary metrics
 		chainsStackSummaryMetrics := [2]chainsStackSummary{
@@ -123,7 +124,7 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 		require.NoError(t, telemetry.Collect(context.Background(), chainsStackSummaryMetrics[0]))
 		require.NoError(t, telemetry.Collect(context.Background(), chainsStackSummaryMetrics[1]))
 
-		metrics, err := s.FetchUnpublishedMetrics(context.Background(), 10)
+		metrics, err := s.FetchMetrics(context.Background(), false, 10)
 		require.NoError(t, err)
 		require.Len(t, metrics, 2)
 
@@ -148,9 +149,93 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 		p.Start()
 
 		require.Eventually(t, func() bool {
-			metrics, err = s.FetchUnpublishedMetrics(context.Background(), 2)
+			metrics, err = s.FetchMetrics(context.Background(), false, 2)
 			require.NoError(t, err)
 			return len(metrics) == 0
+		}, 5*time.Second, time.Second)
+
+		p.Close()
+	})
+
+	t.Run("read query", func(t *testing.T) {
+		// collect two mocked read query metrics
+		readQueryMetrics := [2]readQuery{{}, {}}
+		require.NoError(t, telemetry.Collect(context.Background(), readQueryMetrics[0]))
+		require.NoError(t, telemetry.Collect(context.Background(), readQueryMetrics[1]))
+
+		metrics, err := s.FetchMetrics(context.Background(), false, 10)
+		require.NoError(t, err)
+		require.Len(t, metrics, 2)
+
+		for i, metric := range metrics {
+			require.Equal(t, telemetry.ReadQueryType, metric.Type)
+			require.Equal(t, 1, metric.Version)
+			require.False(t, metric.Timestamp.IsZero())
+
+			payload := metric.Payload.(*telemetry.ReadQueryMetric)
+			require.Equal(t, readQueryMetrics[i].IPAddress(), payload.IPAddress)
+			require.Equal(t, readQueryMetrics[i].SQLStatement(), payload.SQLStatement)
+			require.Equal(t, readQueryMetrics[i].Unwrap(), payload.Unwrap)
+			require.Equal(t, readQueryMetrics[i].Extract(), payload.Extract)
+			require.Equal(t, readQueryMetrics[i].Output(), payload.Output)
+		}
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		exporter, err := publisher.NewHTTPExporter(ts.URL, "")
+		require.NoError(t, err)
+		nodeID := strings.Replace(uuid.NewString(), "-", "", -1)
+		p := publisher.NewPublisher(s, exporter, nodeID, time.Second)
+		p.Start()
+
+		require.Eventually(t, func() bool {
+			metrics, err = s.FetchMetrics(context.Background(), false, 2)
+			require.NoError(t, err)
+			return len(metrics) == 0
+		}, 5*time.Second, time.Second)
+
+		p.Close()
+	})
+
+	t.Run("delete old metrics", func(t *testing.T) {
+		// clear store
+		err := s.DeleteOlderThan(context.Background(), 0)
+
+		require.NoError(t, err)
+		// Store two metrics. One older than 7 days.
+		err = s.StoreMetric(context.Background(), telemetry.Metric{
+			Version:   1,
+			Timestamp: time.Now().UTC(),
+			Type:      telemetry.StateHashType,
+			Payload:   stateHash{},
+		})
+		require.NoError(t, err)
+		err = s.StoreMetric(context.Background(), telemetry.Metric{
+			Version:   1,
+			Timestamp: time.Now().UTC().Add(-24*7*time.Hour - 1), // 7 days + 1 old
+			Type:      telemetry.StateHashType,
+			Payload:   stateHash{},
+		})
+		require.NoError(t, err)
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		exporter, err := publisher.NewHTTPExporter(ts.URL, "")
+		require.NoError(t, err)
+		nodeID := strings.Replace(uuid.NewString(), "-", "", -1)
+		p := publisher.NewPublisher(s, exporter, nodeID, time.Second)
+		p.Start()
+
+		require.Eventually(t, func() bool {
+			metrics, err := s.FetchMetrics(context.Background(), true, 2)
+			require.NoError(t, err)
+			return len(metrics) == 1 // only one published metric is found
 		}, 5*time.Second, time.Second)
 
 		p.Close()
@@ -172,14 +257,14 @@ func (gs gitSummary) GetBinaryVersion() string { return "fakeBinaryVersion" }
 
 type stateHash struct{}
 
-func (h stateHash) ChainID() int64 {
-	return 1
-}
+func (h stateHash) ChainID() int64     { return 1 }
+func (h stateHash) BlockNumber() int64 { return 1 }
+func (h stateHash) Hash() string       { return "abcdefgh" }
 
-func (h stateHash) BlockNumber() int64 {
-	return 1
-}
+type readQuery struct{}
 
-func (h stateHash) Hash() string {
-	return "abcdefgh"
-}
+func (rq readQuery) IPAddress() string    { return "0.0.0.0" }
+func (rq readQuery) SQLStatement() string { return "SELECT * FROM foo" }
+func (rq readQuery) Unwrap() bool         { return false }
+func (rq readQuery) Extract() bool        { return true }
+func (rq readQuery) Output() string       { return "objects" }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -96,6 +96,23 @@ func Collect(ctx context.Context, metric interface{}) error {
 			return errors.Errorf("store chains stacks summary metric: %s", err)
 		}
 		return nil
+	case ReadQuery:
+		if err := metricStore.StoreMetric(ctx, Metric{
+			Version:   1,
+			Timestamp: time.Now().UTC(),
+			Type:      ReadQueryType,
+			Payload: ReadQueryMetric{
+				Version:      1,
+				IPAddress:    v.IPAddress(),
+				SQLStatement: v.SQLStatement(),
+				Unwrap:       v.Unwrap(),
+				Extract:      v.Extract(),
+				Output:       v.Output(),
+			},
+		}); err != nil {
+			return errors.Errorf("read query metric: %s", err)
+		}
+		return nil
 	default:
 		return fmt.Errorf("unknown metric type %T", v)
 	}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -102,12 +102,11 @@ func Collect(ctx context.Context, metric interface{}) error {
 			Timestamp: time.Now().UTC(),
 			Type:      ReadQueryType,
 			Payload: ReadQueryMetric{
-				Version:      1,
-				IPAddress:    v.IPAddress(),
-				SQLStatement: v.SQLStatement(),
-				Unwrap:       v.Unwrap(),
-				Extract:      v.Extract(),
-				Output:       v.Output(),
+				Version:       1,
+				IPAddress:     v.IPAddress(),
+				SQLStatement:  v.SQLStatement(),
+				FormatOptions: v.FormatOptions(),
+				TookMilli:     v.TookMilli(),
 			},
 		}); err != nil {
 			return errors.Errorf("read query metric: %s", err)


### PR DESCRIPTION
# Summary

Starts collecting read query data. Every time we receive a read query, either from REST or JSON RPC, we save the SQL statement, the IP Address, and the formatting options as a metric that will be shipped to BigQuery to be analyzed. 

# Context

Close #319 

# Implementation overview

Most of the implementation is creating the metric and adjusting things so the metric can be collected. 
Other than that, we are now deleting metrics older than 7 days to avoid storage problems. 

# Implementation details and review orientation

NA

