### PR TITLE
analytics: send detected Tableland events and chain blocks as telemetry data

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,6 @@ jobs:
             # Wait to start and double-check we're running the expected version.
             # This helps having a green check in the GH Action be high-signal that everything is fine.
             sleep 5;
-            for i in 1 2 3 4; do [ $(curl --insecure --silent https://127.0.0.1/version | jq .GitCommit) = "\"${{ steps.prep.outputs.sha_short}}\"" ] && break || (if [ $i = 4 ]; then exit -1; else sleep 5; fi ) done 
+            for i in 1 2 3 4; do [ $(curl --insecure --silent https://127.0.0.1/version | jq .git_commit) = "\"${{ steps.prep.outputs.sha_short}}\"" ] && break || (if [ $i = 4 ]; then exit -1; else sleep 5; fi ) done 
             echo "All healthy!"
 

--- a/docker/deployed/staging/api/config.json
+++ b/docker/deployed/staging/api/config.json
@@ -28,7 +28,7 @@
     "Debug": true
   },
   "Analytics": {
-    "FetchExtraBlockInfo": true
+    "FetchExtraBlockInfo": false
   },
   "Backup": {
     "Enabled": true,
@@ -64,7 +64,7 @@
         "ChainAPIBackoff": "15s",
         "NewBlockPollFreq": "10s",
         "MinBlockDepth": 0,
-        "PersistEvents": true
+        "PersistEvents": false
       },
       "EventProcessor": {
         "BlockFailedExecutionBackoff": "10s",

--- a/docker/deployed/staging/api/config.json
+++ b/docker/deployed/staging/api/config.json
@@ -28,7 +28,7 @@
     "Debug": true
   },
   "Analytics": {
-    "FetchExtraBlockInfo": false
+    "FetchExtraBlockInfo": true
   },
   "Backup": {
     "Enabled": true,
@@ -64,7 +64,7 @@
         "ChainAPIBackoff": "15s",
         "NewBlockPollFreq": "10s",
         "MinBlockDepth": 0,
-        "PersistEvents": false
+        "PersistEvents": true
       },
       "EventProcessor": {
         "BlockFailedExecutionBackoff": "10s",

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -22,6 +22,8 @@ const (
 	ReadQueryType
 	// NewBlockType is the type for the NewBlockMetric.
 	NewBlockType
+	// NewTablelandEventType is the type for the NewTablelandEventMetri.
+	NewTablelandEventType
 )
 
 // Metric defines a metric.
@@ -118,11 +120,34 @@ type NewBlockMetricVersion int64
 // NewBlockMetricV1 is the V1 version of NewBlock metric.
 const NewBlockMetricV1 NewBlockMetricVersion = iota
 
-// NewBlockMetric contains information about a newly detected block
+// NewBlockMetric contains information about a newly detected block.
 type NewBlockMetric struct {
 	Version NewBlockMetricVersion `json:"version"`
 
 	ChainID            int    `json:"chain_id"`
 	BlockNumber        int64  `json:"block_number"`
 	BlockTimestampUnix uint64 `json:"block_timestamp_unix"`
+}
+
+// NewTablelandEventMetricVersion is a type for versioning NewTablelandEvent metrics.
+type NewTablelandEventMetricVersion int64
+
+// NewTablelandEventMetricV1 is the V1 version of NewTablelandEvent metric.
+const NewTablelandEventMetricV1 NewTablelandEventMetricVersion = iota
+
+// NewTablelandEventMetric contains information about a newly detected Tableland event.
+type NewTablelandEventMetric struct {
+	Version NewTablelandEventMetricVersion `json:"version"`
+
+	Address     string `json:"address"`
+	Topics      []byte `json:"topics"`
+	Data        []byte `json:"data"`
+	BlockNumber uint64 `json:"block_number"`
+	TxHash      string `json:"tx_hash"`
+	TxIndex     uint   `json:"tx_index"`
+	BlockHash   string `json:"block_hash"`
+	Index       uint   `json:"index"`
+	ChainID     int64  `json:"chain_id"`
+	EventJSON   string `json:"event_json"`
+	EventType   string `json:"event_type"`
 }

--- a/pkg/telemetry/metrics.go
+++ b/pkg/telemetry/metrics.go
@@ -20,6 +20,8 @@ const (
 	ChainStacksSummaryType
 	// ReadQueryType is the type for the ReadQueryMetric.
 	ReadQueryType
+	// NewBlockType is the type for the NewBlockMetric.
+	NewBlockType
 )
 
 // Metric defines a metric.
@@ -108,4 +110,19 @@ type ReadQueryMetric struct {
 	SQLStatement  string                 `json:"sql_statement"`
 	FormatOptions ReadQueryFormatOptions `json:"format_options"`
 	TookMilli     int64                  `json:"took_milli"`
+}
+
+// NewBlockMetricVersion is a type for versioning NewBlock metrics.
+type NewBlockMetricVersion int64
+
+// NewBlockMetricV1 is the V1 version of NewBlock metric.
+const NewBlockMetricV1 NewBlockMetricVersion = iota
+
+// NewBlockMetric contains information about a newly detected block
+type NewBlockMetric struct {
+	Version NewBlockMetricVersion `json:"version"`
+
+	ChainID            int    `json:"chain_id"`
+	BlockNumber        int64  `json:"block_number"`
+	BlockTimestampUnix uint64 `json:"block_timestamp_unix"`
 }

--- a/pkg/telemetry/storage/db.go
+++ b/pkg/telemetry/storage/db.go
@@ -131,7 +131,12 @@ func (db *TelemetryDatabase) FetchMetrics(ctx context.Context, published bool, a
 				return nil, fmt.Errorf("scan rows of system metrics: %s", err)
 			}
 			mType = telemetry.ReadQueryType
-
+		case telemetry.NewBlockType:
+			mPayload = new(telemetry.NewBlockMetric)
+			if err := json.Unmarshal(payload, mPayload); err != nil {
+				return nil, fmt.Errorf("scan rows of system metrics: %s", err)
+			}
+			mType = telemetry.NewBlockType
 		default:
 			return nil, fmt.Errorf("unknown metric type: %d", typ)
 		}

--- a/pkg/telemetry/storage/db.go
+++ b/pkg/telemetry/storage/db.go
@@ -137,6 +137,12 @@ func (db *TelemetryDatabase) FetchMetrics(ctx context.Context, published bool, a
 				return nil, fmt.Errorf("scan rows of system metrics: %s", err)
 			}
 			mType = telemetry.NewBlockType
+		case telemetry.NewTablelandEventType:
+			mPayload = new(telemetry.NewTablelandEventMetric)
+			if err := json.Unmarshal(payload, mPayload); err != nil {
+				return nil, fmt.Errorf("scan rows of system metrics: %s", err)
+			}
+			mType = telemetry.NewTablelandEventType
 		default:
 			return nil, fmt.Errorf("unknown metric type: %d", typ)
 		}

--- a/pkg/telemetry/storage/db_test.go
+++ b/pkg/telemetry/storage/db_test.go
@@ -249,7 +249,7 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 		p.Close()
 	})
 
-	t.Run("new block", func(t *testing.T) {
+	t.Run("new tableland event", func(t *testing.T) {
 		metric := telemetry.NewTablelandEventMetric{
 			Version:     telemetry.NewTablelandEventMetricV1,
 			Address:     "addr",

--- a/pkg/telemetry/storage/db_test.go
+++ b/pkg/telemetry/storage/db_test.go
@@ -45,11 +45,7 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 			require.Equal(t, telemetry.StateHashType, metric.Type)
 			require.Equal(t, 1, metric.Version)
 			require.False(t, metric.Timestamp.IsZero())
-
-			sh := metric.Payload.(*telemetry.StateHashMetric)
-			require.Equal(t, fakeStateHash.ChainID, sh.ChainID)
-			require.Equal(t, fakeStateHash.BlockNumber, sh.BlockNumber)
-			require.Equal(t, fakeStateHash.Hash, sh.Hash)
+			require.Equal(t, &fakeStateHash, metric.Payload.(*telemetry.StateHashMetric))
 		}
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -73,6 +69,15 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 	})
 
 	t.Run("git summary", func(t *testing.T) {
+		fakeGitSummary := telemetry.GitSummaryMetric{
+			Version:       telemetry.GitSummaryMetricV1,
+			GitCommit:     "fakeGitCommit",
+			GitBranch:     "fakeGitBranch",
+			GitState:      "fakeGitState",
+			GitSummary:    "fakeGitSummary",
+			BuildDate:     "fakeGitDate",
+			BinaryVersion: "fakeBinaryVersion",
+		}
 		// collect two mocked gitSummary metrics
 		require.NoError(t, telemetry.Collect(context.Background(), fakeGitSummary))
 		require.NoError(t, telemetry.Collect(context.Background(), fakeGitSummary))
@@ -86,13 +91,7 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 			require.Equal(t, 1, metric.Version)
 			require.False(t, metric.Timestamp.IsZero())
 
-			gv := metric.Payload.(*telemetry.GitSummaryMetric)
-			require.Equal(t, fakeGitSummary.GitCommit, gv.GitCommit)
-			require.Equal(t, fakeGitSummary.GitBranch, gv.GitBranch)
-			require.Equal(t, fakeGitSummary.GitState, gv.GitState)
-			require.Equal(t, fakeGitSummary.GitSummary, gv.GitSummary)
-			require.Equal(t, fakeGitSummary.BuildDate, gv.BuildDate)
-			require.Equal(t, fakeGitSummary.BinaryVersion, gv.BinaryVersion)
+			require.Equal(t, &fakeGitSummary, metric.Payload.(*telemetry.GitSummaryMetric))
 		}
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -164,6 +163,17 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 	})
 
 	t.Run("read query", func(t *testing.T) {
+		fakeReadQuery := telemetry.ReadQueryMetric{
+			Version:      telemetry.ReadQueryMetricV1,
+			IPAddress:    "0.0.0.0",
+			SQLStatement: "SELECT * FROM foo",
+			FormatOptions: telemetry.ReadQueryFormatOptions{
+				Extract: true,
+				Unwrap:  false,
+				Output:  "objects",
+			},
+			TookMilli: 100,
+		}
 		// collect two mocked read query metrics
 		readQueryMetrics := [2]telemetry.ReadQueryMetric{fakeReadQuery, fakeReadQuery}
 		require.NoError(t, telemetry.Collect(context.Background(), readQueryMetrics[0]))
@@ -178,11 +188,7 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 			require.Equal(t, 1, metric.Version)
 			require.False(t, metric.Timestamp.IsZero())
 
-			payload := metric.Payload.(*telemetry.ReadQueryMetric)
-			require.Equal(t, readQueryMetrics[i].IPAddress, payload.IPAddress)
-			require.Equal(t, readQueryMetrics[i].SQLStatement, payload.SQLStatement)
-			require.Equal(t, readQueryMetrics[i].FormatOptions, payload.FormatOptions)
-			require.Equal(t, readQueryMetrics[i].TookMilli, payload.TookMilli)
+			require.Equal(t, &readQueryMetrics[i], metric.Payload.(*telemetry.ReadQueryMetric))
 		}
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -286,31 +292,9 @@ func TestCollectAndFetchAndPublish(t *testing.T) {
 	})
 }
 
-var fakeGitSummary = telemetry.GitSummaryMetric{
-	Version:       telemetry.GitSummaryMetricV1,
-	GitCommit:     "fakeGitCommit",
-	GitBranch:     "fakeGitBranch",
-	GitState:      "fakeGitState",
-	GitSummary:    "fakeGitSummary",
-	BuildDate:     "fakeGitDate",
-	BinaryVersion: "fakeBinaryVersion",
-}
-
 var fakeStateHash = telemetry.StateHashMetric{
 	Version:     telemetry.StateHashMetricV1,
 	ChainID:     1,
 	BlockNumber: 1,
 	Hash:        "abcdefgh",
-}
-
-var fakeReadQuery = telemetry.ReadQueryMetric{
-	Version:      telemetry.ReadQueryMetricV1,
-	IPAddress:    "0.0.0.0",
-	SQLStatement: "SELECT * FROM foo",
-	FormatOptions: telemetry.ReadQueryFormatOptions{
-		Extract: true,
-		Unwrap:  false,
-		Output:  "objects",
-	},
-	TookMilli: 100,
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -61,6 +61,8 @@ func Collect(ctx context.Context, metric interface{}) error {
 		metricType = ReadQueryType
 	case NewBlockMetric:
 		metricType = NewBlockType
+	case NewTablelandEventMetric:
+		metricType = NewTablelandEventType
 	default:
 		return fmt.Errorf("unknown metric type %T", v)
 	}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -49,70 +49,28 @@ func Collect(ctx context.Context, metric interface{}) error {
 		return nil
 	}
 
+	var metricType MetricType
 	switch v := metric.(type) {
 	case StateHashMetric:
-		if err := metricStore.StoreMetric(ctx, Metric{
-			Version:   1,
-			Timestamp: time.Now().UTC(),
-			Type:      StateHashType,
-			Payload: StateHashMetric{
-				Version:     v.Version,
-				ChainID:     v.ChainID,
-				BlockNumber: v.BlockNumber,
-				Hash:        v.Hash,
-			},
-		}); err != nil {
-			return errors.Errorf("store state hash metric: %s", err)
-		}
-		return nil
+		metricType = StateHashType
 	case GitSummaryMetric:
-		if err := metricStore.StoreMetric(ctx, Metric{
-			Version:   1,
-			Timestamp: time.Now().UTC(),
-			Type:      GitSummaryType,
-			Payload: GitSummaryMetric{
-				Version:       v.Version,
-				GitCommit:     v.GitCommit,
-				GitBranch:     v.GitBranch,
-				GitState:      v.GitState,
-				GitSummary:    v.GitSummary,
-				BuildDate:     v.BuildDate,
-				BinaryVersion: v.BinaryVersion,
-			},
-		}); err != nil {
-			return errors.Errorf("store git summary metric: %s", err)
-		}
-		return nil
+		metricType = GitSummaryType
 	case ChainStacksMetric:
-		if err := metricStore.StoreMetric(ctx, Metric{
-			Version:   1,
-			Timestamp: time.Now().UTC(),
-			Type:      ChainStacksSummaryType,
-			Payload: ChainStacksMetric{
-				Version:                   v.Version,
-				LastProcessedBlockNumbers: v.LastProcessedBlockNumbers,
-			},
-		}); err != nil {
-			return errors.Errorf("store chains stacks summary metric: %s", err)
-		}
-		return nil
+		metricType = ChainStacksSummaryType
 	case ReadQueryMetric:
-		if err := metricStore.StoreMetric(ctx, Metric{
-			Version:   1,
-			Timestamp: time.Now().UTC(),
-			Type:      ReadQueryType,
-			Payload: ReadQueryMetric{
-				Version:       v.Version,
-				IPAddress:     v.IPAddress,
-				SQLStatement:  v.SQLStatement,
-				FormatOptions: v.FormatOptions,
-				TookMilli:     v.TookMilli,
-			},
-		}); err != nil {
-			return errors.Errorf("read query metric: %s", err)
-		}
-		return nil
+		metricType = ReadQueryType
+	case NewBlockMetric:
+		metricType = NewBlockType
 	default:
 		return fmt.Errorf("unknown metric type %T", v)
 	}
+	if err := metricStore.StoreMetric(ctx, Metric{
+		Version:   1,
+		Timestamp: time.Now().UTC(),
+		Type:      metricType,
+		Payload:   metric,
+	}); err != nil {
+		return errors.Errorf("store metric: %s", err)
+	}
+	return nil
 }

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -62,6 +62,30 @@ func TestCollectMockedtStore(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, s.called)
 	})
+	t.Run("new tableland event", func(t *testing.T) {
+		s := &store{}
+		metricStore = s
+
+		require.False(t, s.called)
+
+		metric := NewTablelandEventMetric{
+			Version:     NewTablelandEventMetricV1,
+			Address:     "addr",
+			Topics:      []byte("topics"),
+			Data:        []byte("data"),
+			BlockNumber: 1,
+			TxHash:      "txhash",
+			TxIndex:     2,
+			BlockHash:   "blockhash",
+			Index:       3,
+			ChainID:     4,
+			EventJSON:   "eventjson",
+			EventType:   "eventtype",
+		}
+		err := Collect(context.Background(), metric)
+		require.NoError(t, err)
+		require.True(t, s.called)
+	})
 }
 
 func TestCollectUnknownMetric(t *testing.T) {

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -46,6 +46,22 @@ func TestCollectMockedtStore(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, s.called)
 	})
+	t.Run("new block", func(t *testing.T) {
+		s := &store{}
+		metricStore = s
+
+		require.False(t, s.called)
+
+		metric := NewBlockMetric{
+			Version:            NewBlockMetricV1,
+			ChainID:            10,
+			BlockNumber:        11,
+			BlockTimestampUnix: 12,
+		}
+		err := Collect(context.Background(), metric)
+		require.NoError(t, err)
+		require.True(t, s.called)
+	})
 }
 
 func TestCollectUnknownMetric(t *testing.T) {


### PR DESCRIPTION
# Summary

Closes #307

# Context

Our current Retool dashboard is querying our cloud validator directly, which isn't convenient since:
- We're adding analytics load to our main validator.
- The way data is stored in SQLite isn't suitable for analytics.
- Since SQLite is a local database, we needed to add an extra infrastructure piece (postlite) to have a PostgreSQL wire format.

By sending the `system_evm_events` and `system_evm_blocks` as events, we can leverage saving this information in BigQuery and use it as the database for Retool. We'll continue to do other ad-hoc analytics apart from the main dashboard, so we can keep taking advantage of having access to this data to do heavy queries.

After this PR is running in `main` for some days (so we have some data), I'll change the Retool dashboard to start using the Big Query database.

# Implementation overview

We've concluded that we'd add the logic to send events and blocks as new metrics. The information is still saved locally in SQLite since this information is still useful to be queried locally and is part of our generated backups/snapshots. We might reevaluate in the future if this is the case. 

For example, this data isn't operational but accounts for >90% of the backup sizes, which isn't strictly needed for new validators spinup. At some point, we might upload two kinds of backups, one with full events and blocks information and the other with minimal information to bootstrap a node.

# Implementation details and review orientation

No specific orientation is needed.

# Checklist

- [X]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [X]  Are changes covered by existing tests, or were new tests included?
- [X]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [X]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
