### PR TITLE
infra/terraform: automate more tasks & fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ evm_history.db
 # Project
 .env*
 *.ignore
-**/credential_file

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ evm_history.db
 # Project
 .env*
 *.ignore
+**/credential_file

--- a/cmd/metricshub/Makefile
+++ b/cmd/metricshub/Makefile
@@ -10,7 +10,7 @@ deploy-mainnet: check-env
 	gcloud run deploy metricshub-mainnet --source=${PWD}  --set-env-vars="GCP_PROJECT=textile-310716,BIGQUERY_DATASET=tableland_mainnet,BIGQUERY_TABLE=system_metrics,API_KEY=${API_KEY}" --region="us-west1" --allow-unauthenticated
 
 deploy-testnet: check-env
-	gcloud run deploy metricshub-testnet --source=${PWD}  --set-env-vars="GCP_PROJECT=textile-310716,BIGQUERY_DATASET=tableland_testnet,BIGQUERY_TABLE=system_metrics,API_KEY=${API_KEY}" --region="us-west1" --allow-unauthenticated
+	gcloud run deploy metricshub-testnet-v2 --source=${PWD}  --set-env-vars="GCP_PROJECT=textile-310716,BIGQUERY_DATASET=tableland_testnet_v2,BIGQUERY_TABLE=system_metrics,API_KEY=${API_KEY}" --region="us-west1" --allow-unauthenticated
 
 deploy-staging: check-env
 	gcloud run deploy metricshub-staging --source=${PWD}  --set-env-vars="GCP_PROJECT=textile-310716,BIGQUERY_DATASET=tableland_staging,BIGQUERY_TABLE=system_metrics,API_KEY=${API_KEY}" --region="us-west1" --allow-unauthenticated

--- a/cmd/metricshub/Makefile
+++ b/cmd/metricshub/Makefile
@@ -6,6 +6,9 @@ ifndef API_KEY
 	$(error API_KEY is undefined)
 endif
 
+deploy-mainnet: check-env
+	gcloud run deploy metricshub-mainnet --source=${PWD}  --set-env-vars="GCP_PROJECT=textile-310716,BIGQUERY_DATASET=tableland_mainnet,BIGQUERY_TABLE=system_metrics,API_KEY=${API_KEY}" --region="us-west1" --allow-unauthenticated
+
 deploy-testnet: check-env
 	gcloud run deploy metricshub-testnet --source=${PWD}  --set-env-vars="GCP_PROJECT=textile-310716,BIGQUERY_DATASET=tableland_testnet,BIGQUERY_TABLE=system_metrics,API_KEY=${API_KEY}" --region="us-west1" --allow-unauthenticated
 

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -8,3 +8,4 @@
 
 *.json
 *.db
+credentials_file

--- a/infra/Readme.md
+++ b/infra/Readme.md
@@ -2,6 +2,10 @@
 
 The validator provisioner is a Terraform resource for creating an instance of a Tableland Validator in Google Cloud.
 
+## First time setup
+
+The first time you'll have to run `terraform init` to install the necessary plugins.
+
 ## Creating
 
 ```bash

--- a/infra/bootstrap.sh
+++ b/infra/bootstrap.sh
@@ -64,10 +64,15 @@ EOM'
 
 sudo service google-cloud-ops-agent restart
 
-sudo -u validator TBLENV=$(uname -n | cut -d '-' -f 3) -i bash -c '
-git clone https://github.com/tablelandnetwork/go-tableland.git ~/go-tableland
-git checkout jsign/testnetmainnetsplit
 
+sudo -u validator  -i bash <<-'EOF'
+export TBLENV=$(uname -n | cut -d '-' -f 3)
+echo $TBLENV
+
+git clone https://github.com/tablelandnetwork/go-tableland.git ~/go-tableland
+cd ~/go-tableland && git checkout jsign/testnetmainnetsplit
+
+echo "~/go-tableland/${TBLENV}/hello"
 cat /tmp/.env_validator > ~/go-tableland/docker/deployed/${TBLENV}/api/.env_validator
 cat /tmp/.env_grafana > ~/go-tableland/docker/deployed/${TBLENV}/grafana/.env_grafana
 cat /tmp/.env_healthbot > ~/go-tableland/docker/deployed/${TBLENV}/healthbot/.env_healthbot
@@ -76,10 +81,11 @@ cat /tmp/grafana.db > ~/go-tableland/docker/deployed/${TBLENV}/grafana/data/graf
 mkdir ~/.ssh && chmod 700 ~/.ssh
 echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEehs1xfBMLKpwV4sAIko++GQgauYXf5SNY4tl9ArTOG ops@textile.io" > ~/.ssh/authorized_keys
 
-(crontab -l 2>/dev/null; echo "0 0 * * FRI /usr/bin/docker system prune --volumes -f  >> /home/validator/cronrun 2>&1" | crontab - 
-(crontab -l 2>/dev/null; echo "10 * * * * gsutil cp `ls -A -1 /home/validator/go-tableland/docker/deployed/${TBLENV}/api/backups/*.* | tail -n 1` gs://tableland-${TBLENV}/backups/ > /home/validator/gsutil.log 2>&1" | crontab - 
-(crontab -l 2>/dev/null; echo "10 * * * * gsutil cp `ls -A -1 /home/validator/go-tableland/docker/deployed/${TBLENV}/api/backups/*.* | tail -n 1` gs://tableland-${TBLENV}/backups/tbl_backup_latest.db.zst > /home/validator/gsutil.log 2>&1" | crontab -
-'
+echo '
+0 0 * * FRI /usr/bin/docker system prune --volumes -f  >> /home/validator/cronrun 2>&1
+10 * * * * gsutil cp "ls -A -1 /home/validator/go-tableland/docker/deployed/${TBLENV}/api/backups/*.* | tail -n 1" gs://tableland-${TBLENV}/backups/ > /home/validator/gsutil.log 2>&1"
+10 * * * * gsutil cp "ls -A -1 /home/validator/go-tableland/docker/deployed/${TBLENV}/api/backups/*.* | tail -n 1" gs://tableland-${TBLENV}/backups/tbl_backup_latest.db.zst > /home/validator/gsutil.log 2>&1' | crontab -
+EOF
 
 #sudo su - validator -c 'cd ~/go-tableland/docker && make testnet-up'
 

--- a/infra/bootstrap.sh
+++ b/infra/bootstrap.sh
@@ -82,7 +82,7 @@ echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEehs1xfBMLKpwV4sAIko++GQgauYXf5SNY4tl
 crontab - <<-MOF
 0 0 * * FRI /usr/bin/docker system prune --volumes -f  >> /home/validator/cronrun 2>&1
 10 * * * * gsutil rsync /home/validator/go-tableland/docker/deployed/${TBLENV}/api/backups/ gs://tableland-${TBLENV}/backups/ > /home/validator/gsutil.log 2>&1
-10 * * * * gsutil cp "ls -A -1 /home/validator/go-tableland/docker/deployed/${TBLENV}/api/backups/*.* | tail -n 1" gs://tableland-${TBLENV}/backups/tbl_backup_latest.db.zst > /home/validator/gsutil.log 2>&1
+10 * * * * gsutil cp `ls -A -1 /home/validator/go-tableland/docker/deployed/${TBLENV}/api/backups/*.* | tail -n 1` gs://tableland-${TBLENV}/backups/tbl_backup_latest.db.zst > /home/validator/gsutil.log 2>&1
 MOF
 
 EOF

--- a/infra/bootstrap.sh
+++ b/infra/bootstrap.sh
@@ -81,13 +81,13 @@ echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEehs1xfBMLKpwV4sAIko++GQgauYXf5SNY4tl
 
 crontab - <<-MOF
 0 0 * * FRI /usr/bin/docker system prune --volumes -f  >> /home/validator/cronrun 2>&1
-10 * * * * gsutil cp "ls -A -1 /home/validator/go-tableland/docker/deployed/${TBLENV}/api/backups/*.* | tail -n 1" gs://tableland-${TBLENV}/backups/ > /home/validator/gsutil.log 2>&1"
+10 * * * * gsutil rsync /home/validator/go-tableland/docker/deployed/${TBLENV}/api/backups/ gs://tableland-${TBLENV}/backups/ > /home/validator/gsutil.log 2>&1
 10 * * * * gsutil cp "ls -A -1 /home/validator/go-tableland/docker/deployed/${TBLENV}/api/backups/*.* | tail -n 1" gs://tableland-${TBLENV}/backups/tbl_backup_latest.db.zst > /home/validator/gsutil.log 2>&1
 MOF
 
 EOF
 
-#sudo su - validator -c 'cd ~/go-tableland/docker && make testnet-up'
+#sudo su - validator -c 'cd ~/go-tableland/docker && make ${TBLENV}-up'
 
 sudo rm /tmp/.env_grafana
 sudo rm /tmp/.env_validator

--- a/infra/bootstrap.sh
+++ b/infra/bootstrap.sh
@@ -67,12 +67,10 @@ sudo service google-cloud-ops-agent restart
 
 sudo -u validator  -i bash <<-'EOF'
 export TBLENV=$(uname -n | cut -d '-' -f 3)
-echo $TBLENV
 
 git clone https://github.com/tablelandnetwork/go-tableland.git ~/go-tableland
 cd ~/go-tableland && git checkout jsign/testnetmainnetsplit
 
-echo "~/go-tableland/${TBLENV}/hello"
 cat /tmp/.env_validator > ~/go-tableland/docker/deployed/${TBLENV}/api/.env_validator
 cat /tmp/.env_grafana > ~/go-tableland/docker/deployed/${TBLENV}/grafana/.env_grafana
 cat /tmp/.env_healthbot > ~/go-tableland/docker/deployed/${TBLENV}/healthbot/.env_healthbot
@@ -81,10 +79,12 @@ cat /tmp/grafana.db > ~/go-tableland/docker/deployed/${TBLENV}/grafana/data/graf
 mkdir ~/.ssh && chmod 700 ~/.ssh
 echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEehs1xfBMLKpwV4sAIko++GQgauYXf5SNY4tl9ArTOG ops@textile.io" > ~/.ssh/authorized_keys
 
-echo '
+crontab - <<-MOF
 0 0 * * FRI /usr/bin/docker system prune --volumes -f  >> /home/validator/cronrun 2>&1
 10 * * * * gsutil cp "ls -A -1 /home/validator/go-tableland/docker/deployed/${TBLENV}/api/backups/*.* | tail -n 1" gs://tableland-${TBLENV}/backups/ > /home/validator/gsutil.log 2>&1"
-10 * * * * gsutil cp "ls -A -1 /home/validator/go-tableland/docker/deployed/${TBLENV}/api/backups/*.* | tail -n 1" gs://tableland-${TBLENV}/backups/tbl_backup_latest.db.zst > /home/validator/gsutil.log 2>&1' | crontab -
+10 * * * * gsutil cp "ls -A -1 /home/validator/go-tableland/docker/deployed/${TBLENV}/api/backups/*.* | tail -n 1" gs://tableland-${TBLENV}/backups/tbl_backup_latest.db.zst > /home/validator/gsutil.log 2>&1
+MOF
+
 EOF
 
 #sudo su - validator -c 'cd ~/go-tableland/docker && make testnet-up'

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -51,9 +51,9 @@ resource "google_compute_instance" "validator" {
 
     boot_disk {
         initialize_params {
-            image = "ubuntu-2204-jammy-v20220902"
+            image = "ubuntu-minimal-2204-jammy-v20221101"
             type = "pd-ssd"
-            size = "30"
+            size = "50"
         }
     }
     

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -46,8 +46,8 @@ provider "google" {
 resource "google_compute_instance" "validator" {
     name         = "${var.vm_name}"
     machine_type = "${var.machine_type}"
-    tags         = ["https-server", "grafana", "ssh-vm", "allow-retool-postgres"]
-    deletion_protection = true
+    tags         = ["https-server", "grafana", "ssh-vm"]
+    deletion_protection = false
 
     boot_disk {
         initialize_params {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -47,7 +47,7 @@ resource "google_compute_instance" "validator" {
     name         = "${var.vm_name}"
     machine_type = "${var.machine_type}"
     tags         = ["https-server", "grafana", "ssh-vm"]
-    deletion_protection = false
+    deletion_protection = true
 
     boot_disk {
         initialize_params {


### PR DESCRIPTION
# Summary

This is another iteration in our current draft Terraform deployment for gcloud.
The main goal is to automate as much as possible any new validator with this setup:
- Optimize boot disk to use minimal version, and bump size.
- Remove not needed firewall rules considering our latest BQ movements for analytics
- Include crontab rules for backuping, snapshot uploading, and docker pruning.
- Generalize the script that was previously hardcoding `testnet`, to a script that will automatically know where to put target files by using `uname -m` to derive if this is a `staging`, `testnet` or `mainnet` deployment. To avoid an extra Terraform var.

# Context

We're in the process of deploying new validators due to the testnet and mainnet network splits.

# Implementation overview

I'll explain in PR comments when ready.

# Implementation details and review orientation

NA
