### PR TITLE
fix: pass the right animation config value to router

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -483,7 +483,7 @@ func createHTTPServer(
 	router := router.ConfiguredRouter(
 		gatewayConfig.ExternalURIPrefix,
 		gatewayConfig.MetadataRendererURI,
-		gatewayConfig.MetadataRendererURI,
+		gatewayConfig.AnimationRendererURI,
 		httpConfig.MaxRequestPerInterval,
 		rateLimInterval,
 		parser,


### PR DESCRIPTION
# Summary

It was passing the wrong variable to the router. 

# Context

When the PR #332 was rebased the code was wrongly merged. 


