### PR TITLE
toolkit: add nonce txn replacer

### DIFF
--- a/cmd/toolkit/gaspricebumper.go
+++ b/cmd/toolkit/gaspricebumper.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -46,6 +47,46 @@ var gasPriceBumperCmd = &cobra.Command{
 			log.Fatalf("bumpint txn fee: %s", err)
 		}
 		fmt.Printf("The new transaction hash is: %s\n", newTxnHash)
+
+		return nil
+	},
+}
+
+var replaceNonceRangeCmd = &cobra.Command{
+	Use:   "replacenoncerange",
+	Short: "Sends transactions to replace a nonce range",
+	Long:  "Sends transactions to replace a nonce range",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		privateKey, err := cmd.Flags().GetString("privatekey")
+		if err != nil {
+			return errors.New("failed to parse privatekey")
+		}
+		gatewayEndpoint, err := cmd.Flags().GetString("gateway")
+		if err != nil {
+			return errors.New("failed to parse gateway")
+		}
+
+		start, err := strconv.ParseUint(args[0], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid nonce start: %s", err)
+		}
+		end, err := strconv.ParseUint(args[1], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid nonce end: %s", err)
+		}
+
+		conn, err := ethclient.Dial(gatewayEndpoint)
+		if err != nil {
+			log.Fatalf("failed to connect to ethereum endpoint: %s", err)
+		}
+		pk, err := crypto.HexToECDSA(privateKey)
+		if err != nil {
+			log.Fatalf("decoding private key: %s", err)
+		}
+		if err := replaceNonceRange(conn, pk, start, end); err != nil {
+			log.Fatalf("bumpint txn fee: %s", err)
+		}
 
 		return nil
 	},
@@ -105,4 +146,46 @@ func bumpTxnFee(
 	}
 
 	return txn.Hash(), nil
+}
+
+func replaceNonceRange(
+	conn *ethclient.Client,
+	pk *ecdsa.PrivateKey,
+	start, end uint64,
+) error {
+	for nonce := start; nonce <= end; nonce++ {
+		ctx := context.Background()
+
+		candidateGasPriceSuggested, err := conn.SuggestGasPrice(ctx)
+		if err != nil {
+			return fmt.Errorf("get suggested gas price: %s", err)
+		}
+		newGasPrice := candidateGasPriceSuggested.Mul(candidateGasPriceSuggested, big.NewInt(125))
+		newGasPrice = newGasPrice.Div(newGasPrice, big.NewInt(100))
+		fmt.Printf("**New gas price: %s**\n", newGasPrice)
+
+		targetAddress := common.HexToAddress("0xb468b686d190937905b0138c9f5746e9325be121")
+		ltxn := &types.LegacyTx{
+			Nonce:    nonce,
+			GasPrice: newGasPrice,
+			Gas:      21000,
+			To:       &targetAddress,
+			Value:    big.NewInt(0),
+		}
+
+		chainID, err := conn.ChainID(ctx)
+		if err != nil {
+			return fmt.Errorf("get chain id: %s", err)
+		}
+		signer := types.NewLondonSigner(chainID)
+		txn, err := types.SignTx(types.NewTx(ltxn), signer, pk)
+		if err != nil {
+			return fmt.Errorf("signing txn: %s", err)
+		}
+		if err := conn.SendTransaction(ctx, txn); err != nil {
+			return fmt.Errorf("sending txn: %s", err)
+		}
+	}
+
+	return nil
 }

--- a/cmd/toolkit/main.go
+++ b/cmd/toolkit/main.go
@@ -24,6 +24,7 @@ func init() {
 	rootCmd.AddCommand(scCmd)
 	rootCmd.AddCommand(walletCmd)
 	rootCmd.AddCommand(gasPriceBumperCmd)
+	rootCmd.AddCommand(replaceNonceRangeCmd)
 
 	siweCreateCmd.Flags().Duration("duration", time.Hour*24*365*100, "validity duration")
 	siweCreateCmd.Flags().Int("chain-id", 69, "chain id")
@@ -42,4 +43,7 @@ func init() {
 
 	gasPriceBumperCmd.PersistentFlags().String("privatekey", "", "the private key used to make the contract calls")
 	gasPriceBumperCmd.PersistentFlags().String("gateway", "", "URL of an Ethereum node API (i.e: Alchemy/Infura)")
+
+	replaceNonceRangeCmd.PersistentFlags().String("privatekey", "", "the private key used to make the contract calls")
+	replaceNonceRangeCmd.PersistentFlags().String("gateway", "", "URL of an Ethereum node API (i.e: Alchemy/Infura)")
 }


### PR DESCRIPTION
# Summary

Adds an extra subcommand to `toolkit` to replace stuck transactions in a nonce range.

# Context

Sometimes some chains have quick spikes, and the original gas of mempool transactions can't be bumped enough.
Also, if the validator lost track of which are these transactions, we can't replace them.

# Implementation overview

This is a bulletproof solution if the usual mechanisms don't work as expected since:
- It sends a `Send` transaction which has fixed gas cost
- It uses the current suggested price times 1.25x

# Implementation details and review orientation

NA
