### PR TITLE
CI: generate binaries and Docker images

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,61 @@
+name: Generate binaries
+on:
+  release:
+    types:
+      - created
+jobs:
+  binaries:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset_name: api-linux-amd64.tar.gz
+            compress_cmd: tar -czvf
+            build_cmd: docker run -v $PWD:/data golang:1.19 bash -c "cd /data && go build ./cmd/api"
+          - os: windows-latest
+            asset_name: api-windows-amd64.zip
+            compress_cmd: tar.exe -a -c -f
+            build_cmd: go build -o api ./cmd/api
+          - os: macos-latest
+            asset_name: api-darwin-amd64.tar.gz
+            compress_cmd: tar -czvf
+            build_cmd: go build -o api ./cmd/api
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: v1.19.x
+      - name: Build binary
+        run: ${{ matrix.build_cmd }}
+      - name: Pack output
+        run: ${{ matrix.compress_cmd }} ${{ matrix.asset_name }} api
+      - name: Upload binary
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ matrix.asset_name }}
+          asset_name: ${{ matrix.asset_name }}
+          tag: ${{ github.ref_name }}
+          overwrite: true
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          file: ./cmd/api/Dockerfile
+          push: true
+          tags: textile/tableland:latest,textile/tableland:${{ github.ref_name }}
+          platforms: linux/amd64, linux/arm64

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   deploy:
-    if: github.event_name == 'release' || github.ref == 'refs/heads/main' || contains(github.event.head_commit.message, '[stagingdeploy]') || contains(github.event.head_commit.message, '[testnetdeploy]') || contains(github.event.head_commit.message, '[mainnetdeploy]')
+    if: contains(github.event.head_commit.message, '[stagingdeploy]') || contains(github.event.head_commit.message, '[testnetdeploy]') || contains(github.event.head_commit.message, '[mainnetdeploy]')
     name: Deploy
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Summary

This PR includes a new Github Action that is run when a tag is created, which:
- Creates binaries for `linux/amd64`, `windows/amd64`, and `darwin/amd64`
- Create Docker images for `amd64` and `arm64`.

Closes #365.

**Note: This PR is ready for review, but I'll keep it in draft until Bruno returns.**

# Context

This is part of our work to provide more options to validators apart from building from source.

# Implementation overview

Building these binaries isn't as easy as using the cross-compiling feature of Go, since we rely on CGO, which complicates things quite a bit. In particular, for M1 binaries since Github Actions doesn't have `arm64` VMs (at least, yet). I gave it a shot to a QEMU setup to simulate an `arm64` arch on top of `amd64` It was pretty good, but unfortunately, the GCC version that M1 needs is a custom XCode one, so it was getting too complicated. Probably with more time I can find some other workaround if there's some Docker image with this GCC compiler.. so I can use QEMU to simulate the arch.

We can wait for Github Actions to provide a M1 machine setup, or also use something that @asutula  [mentioned](https://discord.com/channels/592843512312102924/1013931507309617232/1052332699576189069) but that has some extra cost. Also, if users with M1 want binaries to run locally, I think somebody can run the `amd64` binary with Rosetta, and it should work too.

For the Docker images, they can be used in M1 since the build process uses QEMU to at least simulate a `arm64` architecture, which should mean that it _should_ be runnable in an M1 (I don't have an M1 machine to verify this yet). So, an M1 machine can run a `linux/arm64` (that's the theory). Building this `arm64` with QEMU takes 10x more time than the `amd64`, but I think that's fine for our CI.


TL;DR:
- If you want to see an example of binaries generated, [see this test release](https://discord.com/channels/592843512312102924/1013931507309617232/1052319113906765874).
- For our Docker images, [see this Dockerhub repo](https://hub.docker.com/repository/docker/textile/tableland/tags?page=1&ordering=last_updated). Notice how there're two architecture versions for the images to provide support for both.


# Implementation details and review orientation

NA

# Checklist
- [X]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [X]  Are changes covered by existing tests, or were new tests included?
- [X]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [X]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
