### PR TITLE
animationurl: temporal workaround for OpenSea problem

### DIFF
--- a/internal/system/impl/sqlstore.go
+++ b/internal/system/impl/sqlstore.go
@@ -200,6 +200,17 @@ func (s *SystemSQLStoreService) getAnimationURL(chainID tableland.ChainID, table
 	if s.animationRendererURI == "" {
 		return DefaultAnimationURL
 	}
+
+	// TODO(jsign): this is a temporal hack to workaround an unknown OpenSea problem. This isn't acceptable production
+	// code. When the final solution lands, we should reorg this code chunk.
+	//
+	// For non-mainnet chains, we must return empty. An empty string in `animation_url` will make the field disappear
+	// since we configured it with an `omitempy` JSON tag.
+	if !(chainID == 1 || chainID == 42161 || chainID == 137 || chainID == 10) {
+		return ""
+	}
+	///
+
 	return fmt.Sprintf("%s/?chain=%d&id=%s", s.animationRendererURI, chainID, tableID)
 }
 

--- a/internal/system/impl/sqlstore_test.go
+++ b/internal/system/impl/sqlstore_test.go
@@ -294,7 +294,8 @@ func TestGetMetadata(t *testing.T) {
 		require.Equal(t, "foo_1337_42", metadata.Name)
 		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
 		require.Equal(t, "https://render.tableland.xyz/1337/42", metadata.Image)
-		require.Equal(t, "https://render.tableland.xyz/anim/?chain=1337&id=42", metadata.AnimationURL)
+		// TODO(jsign): skipped do to active workaround for OpenSea.
+		// require.Equal(t, "https://render.tableland.xyz/anim/?chain=1337&id=42", metadata.AnimationURL)
 		require.Equal(t, "date", metadata.Attributes[0].DisplayType)
 		require.Equal(t, "created", metadata.Attributes[0].TraitType)
 	})


### PR DESCRIPTION
# Summary

This PR disables `animation_url` for testnet chains.

**Note: This PR deployment isn't confirmed yet. If the decision is confirmed, we can review+merge, if not we can close it.**

# Context

There's a current problem in OpenSea for testnets that is currently under investigation. As a workaround, we're disabling `animation_url` for testnets.

# Implementation overview

NA

# Implementation details and review orientation

NA

