### PR TITLE
Avoid html escaping in GetTable API

### DIFF
--- a/internal/router/controllers/system.go
+++ b/internal/router/controllers/system.go
@@ -53,7 +53,9 @@ func (c *SystemController) GetTable(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	rw.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(rw).Encode(metadata)
+	enc := json.NewEncoder(rw)
+	enc.SetEscapeHTML(false)
+	_ = enc.Encode(metadata)
 }
 
 // GetTablesByController handles the GET /chain/{chainID}/tables/controller/{address} call.


### PR DESCRIPTION
# Summary

It avoids HTML escaping in the `GetTables` API.

# Context

This was asked to avoid escaping characters in field values that contain URLs with ampersand, e.g: `"animation_url":"https://render.tableland.xyz/anim/?chain=137\u0026id=29"`

# Implementation overview

NA

# Implementation details and review orientation

NA

