### PR TITLE
add remote workflow trigger binaries.yml

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -61,25 +61,48 @@ jobs:
           platforms: linux/amd64, linux/arm64
   js-release:
     runs-on: ubuntu-latest
+    if: ${{ success() }}
+    needs: [binaries]
     steps:
+      - run: echo "release_version ${{ github.ref_name }}"
+
       - name: PR to publish this release via the npm package
         uses: actions/github-script@v6
         with:
-          # TODO: I think we will need a token with greater permission than this,
-          #       maybe TEXTILEIO_MACHINE_ACCESS_TOKEN will work?
           github-token: ${{ secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN }}
           script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'tablelandnetwork',
-              repo: 'js-validator',
-              workflow_id: 'release-pr.yml',
-              ref: 'main',
-              inputs: {
-                release_version: ${{ github.ref_name }}
+            // This triggers the release-pr workflow in the js-validator repo
+            // which will create a pull request in that repo to update the binaries
+            // on npm with this release
+            try {
+              // TODO: switch back to 'tablelandnetwork'
+              const ownerOrg = 'joewagner';
+
+              // if the tag/release has a preceeding "v" we want to remove
+              // it and match standard symantics in the js ecosystem
+              let version = '${{ github.ref_name }}';
+              if (/^v[0-9]/.test(version)) {
+                version = version.slice(1);
               }
-            }).catch(error => error).then(response => {
-              core.debug(response);
+
+              const options = {
+                owner: ownerOrg,
+                repo: 'js-validator',
+                workflow_id: 'release-pr.yml',
+                ref: 'main',
+                inputs: {
+                  release_version: version
+                }
+              };
+
+              console.log(options);
+
+              const response = await github.rest.actions.createWorkflowDispatch(options);
+
               if (response.status !== 204) {
                 core.setFailed(`create workflow_dispatch received status code ${response.status}`);
               }
-            });
+            } catch(err) {
+              console.log(err);
+              core.setFailed(err.message);
+            }

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -59,3 +59,27 @@ jobs:
           push: true
           tags: textile/tableland:latest,textile/tableland:${{ github.ref_name }}
           platforms: linux/amd64, linux/arm64
+  js-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR to publish this release via the npm package
+        uses: actions/github-script@v6
+        with:
+          # TODO: I think we will need a token with greater permission than this,
+          #       maybe TEXTILEIO_MACHINE_ACCESS_TOKEN will work?
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'tablelandnetwork',
+              repo: 'js-validator',
+              workflow_id: 'release-pr.yml',
+              ref: 'main',
+              inputs: {
+                release_version: ${{ github.ref_name }}
+              }
+            }).catch(error => error).then(response => {
+              core.debug(response);
+              if (response.status !== 204) {
+                core.setFailed(`create workflow_dispatch received status code ${response.status}`);
+              }
+            });

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -75,8 +75,7 @@ jobs:
             // which will create a pull request in that repo to update the binaries
             // on npm with this release
             try {
-              // TODO: switch back to 'tablelandnetwork'
-              const ownerOrg = 'joewagner';
+              const ownerOrg = 'tablelandnetwork';
 
               // if the tag/release has a preceeding "v" we want to remove
               // it and match standard symantics in the js ecosystem

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           # TODO: I think we will need a token with greater permission than this,
           #       maybe TEXTILEIO_MACHINE_ACCESS_TOKEN will work?
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'tablelandnetwork',


### PR DESCRIPTION
## Overview

This pr adds a job to the end of the binaries.yml workflow.  The job is setup to wait until the building of the binaries is finished, then it will trigger a [workflow in the js-validator repo](https://github.com/tablelandnetwork/js-validator/blob/main/.github/workflows/release-pr.yml).

## Details
The workflow that is triggered in the js-validator repo does a few things:
1. It creates a Pull Request to add binaries that were released here to the js-validator repo.
2. In the PR it will also update the version of js-validator to match the go-tableland release.
3. If the js-validator PR is merged, the binaries are automatically published to npm under a version matching the go-tableland release.  Doing this will trigger dependabot enabled downstream consumers to be alerted to the new version.

See https://github.com/tablelandnetwork/js-validator/pull/6 for all the details on what happens in js-validator.
One nuance to the separation of js-validator and this repository is that we can manually update the pull request with alternative builds like M1 ect... if someone on the team wants to experiment with a different arch + os.  

cc: @brunocalza 
