### PR TITLE
fix: get schema was not parsing statements with autoincrement 

### DIFF
--- a/internal/system/impl/sqlstore_test.go
+++ b/internal/system/impl/sqlstore_test.go
@@ -128,7 +128,7 @@ func TestGetSchemaByTableName(t *testing.T) {
 			&ethereum.ContractCreateTable{
 				TableId:   big.NewInt(42),
 				Owner:     common.HexToAddress("0xb451cee4A42A652Fe77d373BAe66D42fd6B8D8FF"),
-				Statement: "create table foo_1337 (a int primary key, b text not null default 'foo' unique, check (a > 0))",
+				Statement: "create table foo_1337 (a integer primary key, b text not null default 'foo' unique, check (a > 0))",
 			},
 		},
 	})
@@ -148,9 +148,9 @@ func TestGetSchemaByTableName(t *testing.T) {
 	require.Len(t, schema.TableConstraints, 1)
 
 	require.Equal(t, "a", schema.Columns[0].Name)
-	require.Equal(t, "int", schema.Columns[0].Type)
+	require.Equal(t, "integer", schema.Columns[0].Type)
 	require.Len(t, schema.Columns[0].Constraints, 1)
-	require.Equal(t, "primary key", schema.Columns[0].Constraints[0])
+	require.Equal(t, "primary key autoincrement", schema.Columns[0].Constraints[0])
 
 	require.Equal(t, "b", schema.Columns[1].Name)
 	require.Equal(t, "text", schema.Columns[1].Type)

--- a/pkg/sqlstore/impl/system/store.go
+++ b/pkg/sqlstore/impl/system/store.go
@@ -246,6 +246,10 @@ func (s *SystemStore) GetSchemaByTableName(ctx context.Context, name string) (sq
 		return sqlstore.TableSchema{}, fmt.Errorf("failed to get the table: %s", err)
 	}
 
+	if strings.Contains(strings.ToLower(createStmt), "autoincrement") {
+		createStmt = strings.Replace(createStmt, "autoincrement", "", -1)
+	}
+
 	index := strings.LastIndex(strings.ToLower(createStmt), "strict")
 	ast, err := sqlparser.Parse(createStmt[:index])
 	if err != nil {


### PR DESCRIPTION
# Summary

When getting the schema of a table we need to parse the statement that is stored in SQLite. Sometimes that statement may come with an `AUTOINCREMENT` (because of the protocol rules that add the `AUTOINCREMENT` keyword automatically when an `INTEGER PRIMARY KEY` is found). However, the `AUTOINCREMENT` keyword is not parsable. So we're getting an error. 

# Context

Closes #428 

# Implementation overview

Simply remove the `AUTOINCREMENT` before parsing.

I don't think removing keywords that are not parsable such as `STRICT` and `AUTOINCREMENT` is a good long-term approach. But this is good enough to solve the `bug`. 

This is also related to https://github.com/tablelandnetwork/go-sqlparser/issues/41. It is kind of weird that the `String` method produces and string that is not compliant with the Tableland SQL. But that's more a matter of definition. Up until now, we've been using the `String` method as a way to get the SQL statement that will be executed in `SQLite`. I'll leave this discussion for the future.

