### PR TITLE
Fix name of remote workflow in binaries.yml

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -87,7 +87,7 @@ jobs:
               const options = {
                 owner: ownerOrg,
                 repo: 'js-validator',
-                workflow_id: 'release-pr.yml',
+                workflow_id: 'validator-update-pr.yml',
                 ref: 'main',
                 inputs: {
                   release_version: version


### PR DESCRIPTION
# Summary
The name of the remote workflow that is triggered when the release binaries are build changed.  This updates the name to enable triggering js-validator's workflow.

# Context
After #429 was merged the name of the remote workflow file changed.  This PR updates the name.
