### PR TITLE
fix: wrong input js release job

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -64,7 +64,7 @@ jobs:
     if: ${{ success() }}
     needs: [binaries]
     steps:
-      - run: echo "release_version ${{ github.ref_name }}"
+      - run: echo "validator_version ${{ github.ref_name }}"
 
       - name: PR to publish this release via the npm package
         uses: actions/github-script@v6
@@ -90,7 +90,7 @@ jobs:
                 workflow_id: 'validator-update-pr.yml',
                 ref: 'main',
                 inputs: {
-                  release_version: version
+                  validator_version: version
                 }
               };
 


### PR DESCRIPTION
# Summary

Fixes the input of the `js-release` job

# Context

When we created the [v1.0.0-beta-1](https://github.com/tablelandnetwork/js-validator/commit/5b19f99824aaab2bcb8096553d85426ed7773bdc) release, the`js-release` job was triggered and it [failed](https://github.com/tablelandnetwork/go-tableland/actions/runs/3949156639/jobs/6760153189):

```
Error: Unexpected inputs provided: ["release_version"]
```

Looking at the [commit](https://github.com/tablelandnetwork/js-validator/commit/5b19f99824aaab2bcb8096553d85426ed7773bdc) history of `js-validator` repo, looks like the input `release_version` was changed to `validator_version`. 

cc @asutula @joewagner 