### PR TITLE
adds missing caret to regex

### DIFF
--- a/pkg/parsing/impl/validator.go
+++ b/pkg/parsing/impl/validator.go
@@ -32,7 +32,7 @@ func New(systemTablePrefixes []string, opts ...parsing.Option) (parsing.SQLValid
 		}
 	}
 
-	tablePrefixRegex := "([A-Za-z]+[A-Za-z0-9_]*)"
+	tablePrefixRegex := "^([A-Za-z]+[A-Za-z0-9_]*)"
 	queryTableNameRegEx, _ := regexp.Compile(fmt.Sprintf("%s*_[0-9]+_[0-9]+$", tablePrefixRegex))
 	createTableNameRegEx, _ := regexp.Compile(fmt.Sprintf("%s*_[0-9]+$", tablePrefixRegex))
 


### PR DESCRIPTION
# Summary

The caret was missing in the regex that validates the table's name


# Context

The regex must match the full table name. The same rule is used in the parser [helper](https://github.com/tablelandnetwork/go-sqlparser/blob/main/helpers.go#L87).

