### PR TITLE
Update the tests to reflect new dns values

### DIFF
--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -55,7 +55,7 @@ type HTTPConfig struct {
 
 // GatewayConfig contains configuration for the Gateway.
 type GatewayConfig struct {
-	ExternalURIPrefix    string `default:"https://testnet.tableland.network"`
+	ExternalURIPrefix    string `default:"https://testnets.tableland.network"`
 	MetadataRendererURI  string `default:""`
 	AnimationRendererURI string `default:""`
 }

--- a/pkg/client/v1/client_test.go
+++ b/pkg/client/v1/client_test.go
@@ -97,7 +97,7 @@ func TestGetTableByID(t *testing.T) {
 
 		table := calls.getTableByID(id)
 		require.NotEmpty(t, fullName, table.Name)
-		require.Equal(t, "https://testnet.tableland.network/chain/1337/tables/1", table.ExternalUrl)
+		require.Equal(t, "https://testnets.tableland.network/chain/1337/tables/1", table.ExternalUrl)
 		require.Equal(t, "https://render.tableland.xyz/anim/?chain=1337&id=1", table.AnimationUrl)
 		require.Equal(t, "https://render.tableland.xyz/1337/1", table.Image)
 

--- a/tests/fullstack/fullstack.go
+++ b/tests/fullstack/fullstack.go
@@ -165,7 +165,7 @@ func CreateFullStack(t *testing.T, deps Deps) FullStack {
 	if systemService == nil {
 		systemService, err = systemimpl.NewSystemSQLStoreService(
 			stores,
-			"https://testnet.tableland.network",
+			"https://testnets.tableland.network",
 			"https://render.tableland.xyz",
 			"https://render.tableland.xyz/anim",
 		)


### PR DESCRIPTION
This updates the default value for the GatewayConfig.ExternalURIPrefix and updates the tests.