### PR TITLE
dockerignore: avoid excluding files that are part of the repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,6 @@
-docker
+docker/**/*.db*
+docker/**/backups
+docker/deployed/**/prometheus
+docker/deployed/**/grafana/data/**
+!docker/deployed/**/grafana/data/.gitkeep
+


### PR DESCRIPTION
# Summary

This PR changes the `.dockerignore` file that removes some files that are part of the repo when building the Docker images. This causes some problems for the "dirtyness" of the git repo in the Docker scratchpad, which ultimately makes the reported git version by te validator to always be `*-dirty`.

Tested with a beta release, and [it's working correctly now](https://tableland.network/api/v1/version).

# Context

NA.

# Implementation overview

NA.

# Implementation details and review orientation

NA

