### PR TITLE
logs: add warn log to detect calls to legacy RPC

### DIFF
--- a/internal/router/middlewares/ratelim.go
+++ b/internal/router/middlewares/ratelim.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/rs/zerolog/log"
 	"github.com/sethvargo/go-limiter/httplimit"
 	"github.com/sethvargo/go-limiter/memorystore"
 	"github.com/textileio/go-tableland/pkg/errors"
@@ -86,6 +87,7 @@ func RateLimitController(cfg RateLimiterConfig) (mux.MiddlewareFunc, error) {
 					_ = json.NewEncoder(w).Encode(errors.ServiceError{Message: "reading request body"})
 					return
 				}
+				log.Warn().Str("body", string(fullBody)).Msg("call to legacy RPC")
 				var rpcMethod struct {
 					Method string `json:"method"`
 				}


### PR DESCRIPTION
# Summary

The legacy API (JSON-RPC) will exist for a limited time. After inspecting our Grafana dashboards, I noticed that we still have some activity. This PR adds a log line in the right place to print more details.

If we know who is still using the old RPC, we can ping them to start using the latest API since JSON-RPC will soon deprecate.

# Context

NA

# Implementation overview

NA

# Implementation details and review orientation

NA

