### PR TITLE
client/v1: allow suggested gas price multiplier & use it in healthbot for Ethereum Goerli

### DIFF
--- a/cmd/healthbot/config.go
+++ b/cmd/healthbot/config.go
@@ -36,8 +36,9 @@ type ChainConfig struct {
 		Tablename      string `default:""`
 	}
 	OverrideClient struct {
-		GatewayEndpoint string
-		ContractAddr    string
+		GatewayEndpoint             string
+		ContractAddr                string
+		SuggestedGasPriceMultiplier float64 `default:"1.0"`
 	}
 }
 

--- a/cmd/healthbot/config.go
+++ b/cmd/healthbot/config.go
@@ -38,7 +38,7 @@ type ChainConfig struct {
 	OverrideClient struct {
 		GatewayEndpoint             string
 		ContractAddr                string
-		SuggestedGasPriceMultiplier float64 `default:"1.0"`
+		SuggestedGasPriceMultiplier float64
 	}
 }
 

--- a/cmd/healthbot/counterprobe/counterprobe_test.go
+++ b/cmd/healthbot/counterprobe/counterprobe_test.go
@@ -22,7 +22,7 @@ func TestProduction(t *testing.T) {
 	client, err := clientV1.NewClient(ctx, wallet, clientV1.NewClientChain(chain))
 	require.NoError(t, err)
 
-	cp, err := New("optimism-mainnet", client, "Runbook_24", time.Second, time.Second*10)
+	cp, err := New("optimism-mainnet", client, "Runbook_24", time.Second, time.Second*10, 1)
 	require.NoError(t, err)
 
 	value, err := cp.healthCheck(context.Background())

--- a/cmd/healthbot/main.go
+++ b/cmd/healthbot/main.go
@@ -72,7 +72,9 @@ func main() {
 			client,
 			chainCfg.Probe.Tablename,
 			checkInterval,
-			receiptTimeout)
+			receiptTimeout,
+			chainCfg.OverrideClient.SuggestedGasPriceMultiplier,
+		)
 		if err != nil {
 			log.Fatal().Err(err).Msg("initializing counter-probe")
 		}

--- a/cmd/healthbot/main.go
+++ b/cmd/healthbot/main.go
@@ -67,13 +67,17 @@ func main() {
 			log.Fatal().Err(err).Msg("error creating tbl client")
 		}
 
+		suggestedGasPriceMultiplier := 1.0
+		if chainCfg.OverrideClient.SuggestedGasPriceMultiplier > 0 {
+			suggestedGasPriceMultiplier = chainCfg.OverrideClient.SuggestedGasPriceMultiplier
+		}
 		cp, err := counterprobe.New(
 			chain.Name,
 			client,
 			chainCfg.Probe.Tablename,
 			checkInterval,
 			receiptTimeout,
-			chainCfg.OverrideClient.SuggestedGasPriceMultiplier,
+			suggestedGasPriceMultiplier,
 		)
 		if err != nil {
 			log.Fatal().Err(err).Msg("initializing counter-probe")

--- a/docker/deployed/testnet/healthbot/config.json
+++ b/docker/deployed/testnet/healthbot/config.json
@@ -25,6 +25,9 @@
                 "CheckInterval": "1h",
                 "ReceiptTimeout": "90s",
                 "Tablename": "${HEALTHBOT_ETHEREUM_GOERLI_TABLE}"
+            },
+            "OverrideClient": {
+                "SuggestedGasPriceMultiplier": 1.2
             }
         },
         {

--- a/pkg/tables/impl/ethereum/client.go
+++ b/pkg/tables/impl/ethereum/client.go
@@ -113,10 +113,10 @@ func (c *Client) RunSQL(
 	if err != nil {
 		return nil, fmt.Errorf("suggest gas price: %s", err)
 	}
-	log.Debug().Int64("suggested_gas_price", gasPrice.Int64()).Msg("suggested gas price")
+	log.Debug().Int64("chain_id", int64(c.chainID)).Int64("sugg_gas_price", gasPrice.Int64()).Msg("suggested gas price")
 	gasPrice.Mul(gasPrice, big.NewInt(int64(conf.SuggestedGasPriceMultiplier*100)))
 	gasPrice.Div(gasPrice, big.NewInt(100))
-	log.Debug().Int64("adjusted_gas_price", gasPrice.Int64()).Msg("adjusted gas price")
+	log.Debug().Int64("chain_id", int64(c.chainID)).Int64("adjusted_gas_price", gasPrice.Int64()).Msg("adjusted gas price")
 
 	auth, err := bind.NewKeyedTransactorWithChainID(c.wallet.PrivateKey(), big.NewInt(int64(c.chainID)))
 	if err != nil {

--- a/pkg/tables/tables.go
+++ b/pkg/tables/tables.go
@@ -58,8 +58,34 @@ type TablelandTables interface {
 	IsOwner(context.Context, common.Address, *big.Int) (bool, error)
 
 	// RunSQL sends a transaction with a SQL statement to the Tabeland Smart Contract.
-	RunSQL(context.Context, common.Address, TableID, string) (Transaction, error)
+	RunSQL(context.Context, common.Address, TableID, string, ...RunSQLOption) (Transaction, error)
 
 	// SetController sends a transaction that sets the controller for a token id in Smart Contract.
 	SetController(context.Context, common.Address, TableID, common.Address) (Transaction, error)
+}
+
+// RunSQLOption changes the behavior of the Write method.
+type RunSQLOption func(*RunSQLConfig) error
+
+// RunSQLConfig contains configuration attributes to call Write.
+type RunSQLConfig struct {
+	SuggestedGasPriceMultiplier float64
+}
+
+// DefaultRunSQLConfig is the default configuration for RunSQL if no options are passed.
+var DefaultRunSQLConfig = RunSQLConfig{
+	SuggestedGasPriceMultiplier: 1.0,
+}
+
+// WithSuggestedPriceMultiplier allows to modify the gas priced to be used with respect with the suggested gas price.
+// For example, if `m=1.2` then the gas price to be used will be `suggestedGasPrice * 1.2`.
+func WithSuggestedPriceMultiplier(m float64) RunSQLOption {
+	return func(wc *RunSQLConfig) error {
+		if m <= 0 {
+			return fmt.Errorf("multiplier should be positive")
+		}
+		wc.SuggestedGasPriceMultiplier = m
+
+		return nil
+	}
 }


### PR DESCRIPTION
# Summary

The Go client (`client/v1`) now accepts an option to amplify the internal suggested gas price it gets from the Ethereum API. If no option is used, the behavior is the same as today (not a breaking change). But now the user can bump the price if he wants the transaction to have a higher priority or avoid "gas refill".

Additionally, we allow a new configuration knob in healthbot so we can specify if any chain will have a gas prices bump.

# Context

The Ethereum Goerli chain sometimes have quick spikes in gas prices, which doesn't play nice with `SuggestedGasPrice(...)`. 


# Implementation overview

NA

# Implementation details and review orientation

NA

# Checklist
- [X]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [X]  Are changes covered by existing tests, or were new tests included?
- [X]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [X]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
