### PR TITLE
Update golangci-lint, lint fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ test-replayhistory:
 
 # Lint
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1 run
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0 run
 .PHONY: lint
 
 # OpenAPI

--- a/pkg/backup/pruner_test.go
+++ b/pkg/backup/pruner_test.go
@@ -14,10 +14,12 @@ func TestPruner(t *testing.T) {
 
 	for n := 1; n <= 10; n++ {
 		for keep := 1; keep <= 5; keep++ {
-			t.Run(fmt.Sprintf("%d-%d", n, keep), func(t *testing.T) {
-				t.Parallel()
-				testPruner(t, n, keep)
-			})
+			func(keep int) {
+				t.Run(fmt.Sprintf("%d-%d", n, keep), func(t *testing.T) {
+					t.Parallel()
+					testPruner(t, n, keep)
+				})
+			}(keep)
 		}
 	}
 }


### PR DESCRIPTION
golangci-lint has been broken when using Go 1.19.x giving some `Can't run linter goanalysis_metalinter: goimports: can't extract issues from gofmt diff output` error. They just released an update that fixes that. It introduced a lint failure I fixed.