### PR TITLE
set AllowTransactionRelay to false in all configs

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -269,10 +269,11 @@ func createChainIDStack(
 		return chains.ChainStack{}, fmt.Errorf("starting event processor: %s", err)
 	}
 	return chains.ChainStack{
-		Store:                 systemStore,
-		Registry:              registry,
-		EventProcessor:        ep,
-		AllowTransactionRelay: config.AllowTransactionRelay,
+		Store:          systemStore,
+		Registry:       registry,
+		EventProcessor: ep,
+		// TODO: we can remove the AllowTransactionRelay config property entirely in a future PR
+		AllowTransactionRelay: false,
 		Close: func(ctx context.Context) error {
 			log.Info().Int64("chain_id", int64(config.ChainID)).Msg("closing stack...")
 			defer log.Info().Int64("chain_id", int64(config.ChainID)).Msg("stack closed")

--- a/docker/deployed/staging/api/config.json
+++ b/docker/deployed/staging/api/config.json
@@ -52,7 +52,7 @@
   "Chains": [
     {
       "Name": "Optimism Goerli",
-      "AllowTransactionRelay": true,
+      "AllowTransactionRelay": false,
       "ChainID": 420,
       "Registry": {
         "EthEndpoint": "wss://opt-goerli.g.alchemy.com/v2/${VALIDATOR_ALCHEMY_OPTIMISM_GOERLI_API_KEY}",

--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -54,7 +54,7 @@
         {
             "Name": "Ethereum Goerli",
             "ChainID": 5,
-            "AllowTransactionRelay": true,
+            "AllowTransactionRelay": false,
             "Registry": {
                 "EthEndpoint": "wss://eth-goerli.alchemyapi.io/v2/${VALIDATOR_ALCHEMY_ETHEREUM_GOERLI_API_KEY}",
                 "ContractAddress": "0xDA8EA22d092307874f30A1F277D1388dca0BA97a"
@@ -82,7 +82,7 @@
         {
             "Name": "Polygon Mumbai",
             "ChainID": 80001,
-            "AllowTransactionRelay": true,
+            "AllowTransactionRelay": false,
             "Registry": {
                 "EthEndpoint": "wss://polygon-mumbai.g.alchemy.com/v2/${VALIDATOR_ALCHEMY_POLYGON_MUMBAI_API_KEY}",
                 "ContractAddress": "0x4b48841d4b32C4650E4ABc117A03FE8B51f38F68"
@@ -110,7 +110,7 @@
         {
             "Name": "Arbitrum Goerli",
             "ChainID": 421613,
-            "AllowTransactionRelay": true,
+            "AllowTransactionRelay": false,
             "Registry": {
                 "EthEndpoint": "wss://arb-goerli.g.alchemy.com/v2/${VALIDATOR_ALCHEMY_ARBITRUM_GOERLI_API_KEY}",
                 "ContractAddress": "0x033f69e8d119205089Ab15D340F5b797732f646b"
@@ -137,7 +137,7 @@
         },
         {
             "Name": "Optimism Goerli",
-            "AllowTransactionRelay": true,
+            "AllowTransactionRelay": false,
             "ChainID": 420,
             "Registry": {
                 "EthEndpoint": "wss://opt-goerli.g.alchemy.com/v2/${VALIDATOR_ALCHEMY_OPTIMISM_GOERLI_API_KEY}",

--- a/docker/local/api/config.json
+++ b/docker/local/api/config.json
@@ -12,7 +12,7 @@
     {
       "Name": "Local Hardhat",
       "ChainID": 31337,
-      "AllowTransactionRelay": true,
+      "AllowTransactionRelay": false,
       "Registry": {
         "EthEndpoint": "ws://host.docker.internal:8545",
         "ContractAddress": "[FILL ME]"


### PR DESCRIPTION
# Summary

This PR will turn off all transaction relaying and enable upgrading the registry contract to disallow contract owner calling functions on behalf of eoas. https://github.com/tablelandnetwork/evm-tableland/pull/307

# Context

This is a first step in shutting down and removing the legacy JSON-RPC API. #460 

# Implementation overview

The implementation is fairly simple.  The config files have all been changed so the `AllowTransactionRelay` value is false.  

# Implementation details and review orientation

Along with changing the config files, this somewhat redundantly forces all `ChainStack`s so`AllowTransactionRelay` value is false.  

# Checklist

- [x]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [x]  Are changes covered by existing tests, or were new tests included?
- [x]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [x]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
