### PR TITLE
fix: read query validation not considering compound select 

### DIFF
--- a/pkg/parsing/impl/validator.go
+++ b/pkg/parsing/impl/validator.go
@@ -201,7 +201,7 @@ func (pp *QueryValidator) ValidateReadQuery(query string) (parsing.ReadStmt, err
 		return nil, fmt.Errorf("empty-statement check: %w", err)
 	}
 
-	if _, ok := ast.Statements[0].(*sqlparser.Select); !ok {
+	if _, ok := ast.Statements[0].(sqlparser.ReadStatement); !ok {
 		return nil, errors.New("the query isn't a read-query")
 	}
 


### PR DESCRIPTION
# Summary

The validator parser check was not considering compound select as a possible read query.

# Context

@asutula was trying to execute the compound [query](https://testnets.tableland.network/api/v1/query?statement=select%0A%20%20%20%20rig_id%2C%0A%20%20%20%20%27display_type%27%20as%20display_type%2C%0A%20%20%20%20case%20deal_number%0A%20%20%20%20%20%20when%201%20then%20%27deal%201%27%0A%20%20%20%20%20%20when%202%20then%20%27deal%202%27%0A%20%20%20%20end%20trait_type%2C%0A%20%20%20%20deal_id%20as%20value%0A%20%20from%20deals_80001_5600%0A%20%20union%0A%20%20select%20%0A%20%20%20%20rig_id%2C%0A%20%20%20%20display_type%2C%0A%20%20%20%20trait_type%2C%0A%20%20%20%20value%20%0A%20%20from%20rig_attributes_80001_5599%3B) and that returned an error. That query is allowed and should be executed. It is not returning an error now, because the changed was deployed already.

# Implementation overview

Simply use the `ReadStatement` interface that captures both `*Select` and `*CompoundSelect`

