### PR TITLE
upgrade the actions/setup-go action

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: v1.19.x
       - name: Build binary

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.19
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/textileio/go-tableland
 
-go 1.19
+go 1.18
 
 require (
 	cloud.google.com/go/bigquery v1.45.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/textileio/go-tableland
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/bigquery v1.45.0


### PR DESCRIPTION
# Summary

I noticed that the binaries.yml workflow failed with a message saying "Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-go@v2." https://github.com/tablelandnetwork/go-tableland/actions/runs/4204737716

I'm not sure if upgrading the setup-go action to v3 will fix the issue that caused the binaries build to fail, but seems like a good thing to do anyway. 

# Context

n/a

# Implementation overview

n/a

# Implementation details and review orientation

n/a

# Checklist

- [x]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [x]  Are changes covered by existing tests, or were new tests included?
- [x]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [x]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
