### PR TITLE
Fixes binaries workflow

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -11,7 +11,7 @@ jobs:
           - os: ubuntu-latest
             asset_name: api-linux-amd64.tar.gz
             compress_cmd: tar -czvf
-            build_cmd: docker run -v $PWD:/data golang:1.19 bash -c "cd /data && go build ./cmd/api"
+            build_cmd: docker run -v $PWD:/data golang:1.19 bash -c "git config --global --add safe.directory /data && cd /data && go build ./cmd/api"
           - os: windows-latest
             asset_name: api-windows-amd64.zip
             compress_cmd: tar.exe -a -c -f


### PR DESCRIPTION
# Summary

This PR fixes the problem that occurred while generating the [v1.0.1-beta-4](https://github.com/tablelandnetwork/go-tableland/actions/runs/4204737716/jobs/7376801645) release. 

# Context
For some reason, the `go build` on `ubuntu-latest` was failing with the message 

```
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```

I could do `go build -buildvcs=false ./cmd/api` to make the workflow work again but that error usually happens when there's something misconfigured in the `.git` repository. 

I'm unsure what has changed since the last `v1.0.1-beta-3` release. But after some debugging (I added a `git status` in the middle of the build), I noticed that [the real issue was](https://github.com/tablelandnetwork/go-tableland/actions/runs/4245120022/jobs/7380200498):

```
fatal: detected dubious ownership in repository at '/data'
To add an exception for this directory, call:

	git config --global --add safe.directory /data
```
So I added `git config --global --add safe.directory /data` to the build process for `ubuntu-latest`. 

In short, the `go build` was failing to obtain VCS status because `git` had detected dubious ownership in repository.

In my tests that worked. But we'll only see if this truly works after we generate another release. 

