### PR TITLE
Fixes api gen command to work on M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,12 @@ APIV1=${PWD}/internal/router/controllers/apiv1
 gen-api-v1:
 	mkdir -p ${APIV1}
 	curl -s ${SPEC_URL} > ${APIV1}/tableland-openapi-spec.yaml
-	docker run -w /gen -e GEN_DIR=/gen -v ${APIV1}:/gen swaggerapi/swagger-codegen-cli-v3:3.0.36 \
-	   generate --lang go-server -o /gen -i tableland-openapi-spec.yaml --additional-properties=packageName=apiv1 
+	docker run -w /gen -e GEN_DIR=/gen -v ${APIV1}:/gen --entrypoint /bin/sh bcalza/swagger-codegen-cli:3.0.41 -lc \
+	"   java -jar /opt/swagger-codegen-cli/swagger-codegen-cli.jar generate --lang go-server -o /gen -i tableland-openapi-spec.yaml --additional-properties=packageName=apiv1 \
+		&& cd /gen \
+		&& mv go/* . \
+		&& rm -rf go main.go Dockerfile README.md api .swagger-codegen .swagger-codegen-ignore *.yaml \
+		&& sed -i 's/\*OneOfTableAttributesValue/interface{}/' model_table_attributes.go \
+	"
 	sudo chown -R ${USER} ${APIV1} 
-	cd ${APIV1} && \
-	   mv go/* . && \
-	   rm -rf go main.go Dockerfile README.md api .swagger-codegen .swagger-codegen-ignore *.yaml
-	sed -i 's/\*OneOfTableAttributesValue/interface{}/' internal/router/controllers/apiv1/model_table_attributes.go
 .PHONY: gen-api-v1

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ APIV1=${PWD}/internal/router/controllers/apiv1
 gen-api-v1:
 	mkdir -p ${APIV1}
 	curl -s ${SPEC_URL} > ${APIV1}/tableland-openapi-spec.yaml
-	docker run -w /gen -e GEN_DIR=/gen -v ${APIV1}:/gen --entrypoint /bin/sh bcalza/swagger-codegen-cli:3.0.41 -lc \
+	docker run -w /gen -e GEN_DIR=/gen -v ${APIV1}:/gen --entrypoint /bin/sh textile/swagger-codegen-cli:3.0.41 -lc \
 	"   java -jar /opt/swagger-codegen-cli/swagger-codegen-cli.jar generate --lang go-server -o /gen -i tableland-openapi-spec.yaml --additional-properties=packageName=apiv1 \
 		&& cd /gen \
 		&& mv go/* . \


### PR DESCRIPTION
# Summary

Fixes the command `make gen-api-v1` to work on M1 Mac.


# Context

The command was not working because the docker image `swaggerapi/swagger-codegen-cli` was not built for `arm64` platform. 

Closes #468 

# Implementation overview

- I built a new image for both platforms by doing the following:
  ```
  git clone https://github.com/swagger-api/swagger-codegen/ && cd swagger-codegen
  git checkout v3.0.41
  ./run-in-docker.sh mvn clean package
  cd modules/swagger-codegen-cli
  docker buildx build \
    --platform=linux/amd64,linux/arm64 \
    -f Dockerfile \
    --push \
    -t textile/swagger-codegen-cli:3.0.41 \
    -t textile/swagger-codegen-cli:latest \
    .
  ```

- Also, I've put the cleanup commands after code generation to be run inside the docker container and not outside because the `sed` command in Mac is different from the one running in Linux. 

- Check the docker hub [repo](https://hub.docker.com/repository/docker/textile/swagger-codegen-cli/general).
 