### PR TITLE
Add arbitrum nova config

### DIFF
--- a/docker/deployed/mainnet/api/config.json
+++ b/docker/deployed/mainnet/api/config.json
@@ -108,20 +108,20 @@
             "HashCalculationStep": 450
         },
         {
-            "Name": "Polygon Mainnet",
-            "ChainID": 137,
+            "Name": "Arbitrum Nova Mainnet",
+            "ChainID": 42170,
             "AllowTransactionRelay": false,
             "Registry": {
-                "EthEndpoint": "wss://polygon-mainnet.g.alchemy.com/v2/${VALIDATOR_ALCHEMY_POLYGON_MAINNET_API_KEY}",
-                "ContractAddress": "0x5c4e6A9e5C1e1BF445A062006faF19EA6c49aFeA"
+                "EthEndpoint": "https://distinguished-burned-cherry.nova-mainnet.discover.quiknode.pro/${VALIDATOR_QUICKNODE_ARBITRUM_NOVA_MAINNET_API_KEY}",
+                "ContractAddress": "0x4dad9cbBeDF7934B20641F135bb1202c123AbBD5"
             },
             "Signer": {
-                "PrivateKey": "${VALIDATOR_POLYGON_MAINNET_SIGNER_PRIVATE_KEY}"
+                "PrivateKey": "${VALIDATOR_ARBITRUM_NOVA_MAINNET_SIGNER_PRIVATE_KEY}"
             },
             "EventFeed": {
                 "ChainAPIBackoff": "15s",
                 "NewBlockPollFreq": "5s",
-                "MinBlockDepth": 1,
+                "MinBlockDepth": 0,
                 "PersistEvents": true
             },
             "EventProcessor": {
@@ -129,11 +129,11 @@
                 "DedupExecutedTxns": true
             },
             "NonceTracker": {
-                "CheckInterval": "15s",
+                "CheckInterval": "20s",
                 "StuckInterval": "10m",
-                "MinBlockDepth": 1
+                "MinBlockDepth": 0
             },
-            "HashCalculationStep": 360
+            "HashCalculationStep": 450
         },
         {
             "Name": "Optimism Mainnet",

--- a/docker/deployed/mainnet/api/config.json
+++ b/docker/deployed/mainnet/api/config.json
@@ -110,9 +110,8 @@
         {
             "Name": "Arbitrum Nova Mainnet",
             "ChainID": 42170,
-            "AllowTransactionRelay": false,
             "Registry": {
-                "EthEndpoint": "https://distinguished-burned-cherry.nova-mainnet.discover.quiknode.pro/${VALIDATOR_QUICKNODE_ARBITRUM_NOVA_MAINNET_API_KEY}",
+                "EthEndpoint": "https://skilled-yolo-mountain.nova-mainnet.discover.quiknode.pro/",
                 "ContractAddress": "0x1A22854c5b1642760a827f20137a67930AE108d2"
             },
             "Signer": {

--- a/docker/deployed/mainnet/api/config.json
+++ b/docker/deployed/mainnet/api/config.json
@@ -113,7 +113,7 @@
             "AllowTransactionRelay": false,
             "Registry": {
                 "EthEndpoint": "https://distinguished-burned-cherry.nova-mainnet.discover.quiknode.pro/${VALIDATOR_QUICKNODE_ARBITRUM_NOVA_MAINNET_API_KEY}",
-                "ContractAddress": "0x4dad9cbBeDF7934B20641F135bb1202c123AbBD5"
+                "ContractAddress": "0x1A22854c5b1642760a827f20137a67930AE108d2"
             },
             "Signer": {
                 "PrivateKey": "${VALIDATOR_ARBITRUM_NOVA_MAINNET_SIGNER_PRIVATE_KEY}"
@@ -134,6 +134,34 @@
                 "MinBlockDepth": 0
             },
             "HashCalculationStep": 450
+        },
+        {
+            "Name": "Polygon Mainnet",
+            "ChainID": 137,
+            "AllowTransactionRelay": false,
+            "Registry": {
+                "EthEndpoint": "wss://polygon-mainnet.g.alchemy.com/v2/${VALIDATOR_ALCHEMY_POLYGON_MAINNET_API_KEY}",
+                "ContractAddress": "0x5c4e6A9e5C1e1BF445A062006faF19EA6c49aFeA"
+            },
+            "Signer": {
+                "PrivateKey": "${VALIDATOR_POLYGON_MAINNET_SIGNER_PRIVATE_KEY}"
+            },
+            "EventFeed": {
+                "ChainAPIBackoff": "15s",
+                "NewBlockPollFreq": "5s",
+                "MinBlockDepth": 1,
+                "PersistEvents": true
+            },
+            "EventProcessor": {
+                "BlockFailedExecutionBackoff": "10s",
+                "DedupExecutedTxns": true
+            },
+            "NonceTracker": {
+                "CheckInterval": "15s",
+                "StuckInterval": "10m",
+                "MinBlockDepth": 1
+            },
+            "HashCalculationStep": 360
         },
         {
             "Name": "Optimism Mainnet",

--- a/docker/deployed/mainnet/api/config.json
+++ b/docker/deployed/mainnet/api/config.json
@@ -111,7 +111,7 @@
             "Name": "Arbitrum Nova Mainnet",
             "ChainID": 42170,
             "Registry": {
-                "EthEndpoint": "https://skilled-yolo-mountain.nova-mainnet.discover.quiknode.pro/",
+                "EthEndpoint": "https://skilled-yolo-mountain.nova-mainnet.discover.quiknode.pro/${VALIDATOR_QUICKNODE_ARBITRUM_NOVA_MAINNET_API_KEY}",
                 "ContractAddress": "0x1A22854c5b1642760a827f20137a67930AE108d2"
             },
             "Signer": {

--- a/pkg/client/chains.go
+++ b/pkg/client/chains.go
@@ -19,6 +19,7 @@ var ChainIDs = struct {
 	Optimism       ChainID
 	Polygon        ChainID
 	Arbitrum       ChainID
+	ArbitrumNova   ChainID
 	EthereumGoerli ChainID
 	OptimismGoerli ChainID
 	ArbitrumGoerli ChainID
@@ -29,6 +30,7 @@ var ChainIDs = struct {
 	Optimism:       10,
 	Polygon:        137,
 	Arbitrum:       42161,
+	ArbitrumNova:   42170,
 	EthereumGoerli: 5,
 	OptimismGoerli: 420,
 	ArbitrumGoerli: 421613,
@@ -69,6 +71,12 @@ var Chains = map[ChainID]Chain{
 		ID:           ChainIDs.Arbitrum,
 		Name:         "Arbitrum",
 		ContractAddr: common.HexToAddress("0x9aBd75E8640871A5a20d3B4eE6330a04c962aFfd"),
+	},
+	ChainIDs.ArbitrumNova: {
+		Endpoint:     mainnetURL,
+		ID:           ChainIDs.ArbitrumNova,
+		Name:         "Arbitrum Nova",
+		ContractAddr: common.HexToAddress("0x4dad9cbBeDF7934B20641F135bb1202c123AbBD5"),
 	},
 	ChainIDs.EthereumGoerli: {
 		Endpoint:     testnetURL,
@@ -129,6 +137,10 @@ var AlchemyURLs = map[ChainID]string{
 	ChainIDs.Arbitrum:       "https://arb-mainnet.g.alchemy.com/v2/%s",
 	ChainIDs.PolygonMumbai:  "https://polygon-mumbai.g.alchemy.com/v2/%s",
 	ChainIDs.Polygon:        "https://polygon-mainnet.g.alchemy.com/v2/%s",
+}
+
+var QuickNodeURLs = map[ChainID]string{
+	ChainIDs.ArbitrumNova: "https://distinguished-burned-cherry.nova-mainnet.discover.quiknode.pro/%s",
 }
 
 // LocalURLs contains the URLs for a local network.

--- a/pkg/client/chains.go
+++ b/pkg/client/chains.go
@@ -76,7 +76,7 @@ var Chains = map[ChainID]Chain{
 		Endpoint:     mainnetURL,
 		ID:           ChainIDs.ArbitrumNova,
 		Name:         "Arbitrum Nova",
-		ContractAddr: common.HexToAddress("0x4dad9cbBeDF7934B20641F135bb1202c123AbBD5"),
+		ContractAddr: common.HexToAddress("0x1a22854c5b1642760a827f20137a67930ae108d2"),
 	},
 	ChainIDs.EthereumGoerli: {
 		Endpoint:     testnetURL,
@@ -139,9 +139,9 @@ var AlchemyURLs = map[ChainID]string{
 	ChainIDs.Polygon:        "https://polygon-mainnet.g.alchemy.com/v2/%s",
 }
 
-// QuickNodeURLs contains the URLs for supported chains for QuikNode.
+// QuickNodeURLs contains the URLs for supported chains for QuickNode.
 var QuickNodeURLs = map[ChainID]string{
-	ChainIDs.ArbitrumNova: "https://distinguished-burned-cherry.nova-mainnet.discover.quiknode.pro/%s",
+	ChainIDs.ArbitrumNova: "https://skilled-yolo-mountain.nova-mainnet.discover.quiknode.pro/%s",
 }
 
 // LocalURLs contains the URLs for a local network.

--- a/pkg/client/chains.go
+++ b/pkg/client/chains.go
@@ -139,6 +139,7 @@ var AlchemyURLs = map[ChainID]string{
 	ChainIDs.Polygon:        "https://polygon-mainnet.g.alchemy.com/v2/%s",
 }
 
+// QuickNodeURLs contains the URLs for supported chains for QuikNode.
 var QuickNodeURLs = map[ChainID]string{
 	ChainIDs.ArbitrumNova: "https://distinguished-burned-cherry.nova-mainnet.discover.quiknode.pro/%s",
 }

--- a/pkg/eventprocessor/eventfeed/impl/eventfeed.go
+++ b/pkg/eventprocessor/eventfeed/impl/eventfeed.go
@@ -165,7 +165,8 @@ func (ef *EventFeed) Start(
 				ef.log.Warn().Err(err).Msgf("filter logs from %d to %d", fromHeight, toHeight)
 				if strings.Contains(err.Error(), "read limit exceeded") ||
 					strings.Contains(err.Error(), "Log response size exceeded") ||
-					strings.Contains(err.Error(), "is greater than the limit") {
+					strings.Contains(err.Error(), "is greater than the limit") ||
+					strings.Contains(err.Error(), "eth_getLogs and eth_newFilter are limited to a 10,000 blocks range") {
 					ef.maxBlocksFetchSize = ef.maxBlocksFetchSize * 80 / 100
 				} else {
 					time.Sleep(ef.config.ChainAPIBackoff)


### PR DESCRIPTION
# Summary

This PR integrates the validator with the Arbitrum Nova network. 

# Context

Arbitrum Nova is a [Arbitrum public chain](https://developer.arbitrum.io/public-chains) built on top of the [AnyTrust](https://developer.arbitrum.io/inside-anytrust). It is cheaper than other rollups because it doesn't rely on the L1 chain for data availability. Instead, the DA is guaranteed by a committee. It means that in practice tableland's create and update queries could be performed for ~ $0.001 per query. It makes the tableland network with Arbitrum highly affordable for use cases that have a high write volume.

# Implementation overview

This PR simply adds a new mainnet config. The config includes an endpoint to fetch events from the Arbirtum Nova blockchain. We will use a `quicknode` endpoint for this purpose. The `eventfeed` connects with the Arbitrum Nova chain using the endpoint. And replays the queries on the SQLite database.


_Here are some new tables that are created on Nova (chain id: 42170) after syncing._

<img width="660" alt="Screenshot 2023-03-21 at 10 43 38 PM" src="https://user-images.githubusercontent.com/5305984/226689096-76433a9b-0fbd-4458-8d30-1cd0c1538547.png">


# Checklist
- [x]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [x]  Are changes covered by existing tests, or were new tests included?
- [x]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [x]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
- [x] Add required env vars on the vm
