### PR TITLE
Update config.json

### DIFF
--- a/docker/deployed/testnet/healthbot/config.json
+++ b/docker/deployed/testnet/healthbot/config.json
@@ -22,7 +22,7 @@
             "WalletPrivateKey": "${HEALTHBOT_ETHEREUM_GOERLI_PRIVATE_KEY}",
             "AlchemyAPIKey": "${HEALTHBOT_ALCHEMY_ETHEREUM_GOERLI_API_KEY}",
             "Probe": {
-                "CheckInterval": "1h",
+                "CheckInterval": "1.5h",
                 "ReceiptTimeout": "90s",
                 "Tablename": "${HEALTHBOT_ETHEREUM_GOERLI_TABLE}"
             },
@@ -46,7 +46,7 @@
             "WalletPrivateKey": "${HEALTHBOT_OPTIMISM_GOERLI_PRIVATE_KEY}",
             "AlchemyAPIKey": "${HEALTHBOT_ALCHEMY_OPTIMISM_GOERLI_API_KEY}",
             "Probe": {
-                "CheckInterval": "360s",
+                "CheckInterval": "1h",
                 "ReceiptTimeout": "25s",
                 "Tablename": "${HEALTHBOT_OPTIMISM_GOERLI_TABLE}"
             }


### PR DESCRIPTION
This PR increases `CheckInterval` on goerli and optimism goerli to avoid frequently draining the wallet.


`Healthbot` performs and end to end check on all supported blockchains. It increases a variable in the smart contract. But to do so, it has to pay the transaction fee. We have noted that recently Goerli and Optimism-Goerli networks have gotten more expensive. To avoid frequent refills we are reducing the check interval on these two chains.
