### PR TITLE
Bumps the parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/sethvargo/go-limiter v0.7.2
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.2
-	github.com/tablelandnetwork/sqlparser v0.0.0-20221230162331-b318f234cefd
+	github.com/tablelandnetwork/sqlparser v0.0.0-20230328132500-785ebca8e351
 	github.com/textileio/cli v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0
 	go.opentelemetry.io/otel v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -1295,6 +1295,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a h1:1ur3QoCqvE5f
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/tablelandnetwork/sqlparser v0.0.0-20221230162331-b318f234cefd h1:AbpyzqlTban/UqJTrotlpWC9q/ePGU4qsrvqjoiLmG4=
 github.com/tablelandnetwork/sqlparser v0.0.0-20221230162331-b318f234cefd/go.mod h1:S+M/v3Q8X+236kQxMQziFcLId2Cscb1LzW06IUVhljE=
+github.com/tablelandnetwork/sqlparser v0.0.0-20230328132500-785ebca8e351 h1:aHuHicCezduOZVQXPXFM5MJ+h73caB2OUvVjGffzIsc=
+github.com/tablelandnetwork/sqlparser v0.0.0-20230328132500-785ebca8e351/go.mod h1:S+M/v3Q8X+236kQxMQziFcLId2Cscb1LzW06IUVhljE=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/textileio/cli v1.0.2 h1:qSp/x4d/9SZ93TxhgZnE5okRKqzqHqrzAwKAPjuPw50=
 github.com/textileio/cli v1.0.2/go.mod h1:vTlCvvVyOmXXLwddCcBg3PDavfUsCkRBZoyr6Nu1lkc=

--- a/pkg/client/v1/client_test.go
+++ b/pkg/client/v1/client_test.go
@@ -114,7 +114,7 @@ func TestGetTableByID(t *testing.T) {
 		require.Equal(t, "default 'foo'", table.Schema.Columns[0].Constraints[0])
 
 		require.Len(t, table.Schema.TableConstraints, 1)
-		require.Equal(t, "check(zar > 0)", table.Schema.TableConstraints[0])
+		require.Equal(t, "check(zar>0)", table.Schema.TableConstraints[0])
 	})
 	t.Run("status 404", func(t *testing.T) {
 		calls := setup(t)

--- a/pkg/eventprocessor/impl/eventprocessor_replayhistory_test.go
+++ b/pkg/eventprocessor/impl/eventprocessor_replayhistory_test.go
@@ -35,14 +35,14 @@ func TestReplayProductionHistory(t *testing.T) {
 	}
 
 	expectedStateHashes := map[tableland.ChainID]string{
-		1:      "ce4f083e256d3458a329b6cd1ba7d8e93d9703b3",
-		5:      "08af7e7055f266ea75d3b06350c47a52cfa59843",
-		10:     "2bce2d62e7f5eeadc4736f470ca2959b871e5d91",
-		69:     "643af9ad784444242c6ef415727203941a720197",
-		137:    "b5fb42f3538738ab5856abf9e3b2e38d82378ca4",
-		420:    "184800f533f4edd186853a85829fad8bc7802c4e",
-		80001:  "9336d3a3a36e57a86e4f95d3464048c954e46bc6",
-		421613: "073727932afcee9a5dba19f43c023689ca855dc2",
+		1:      "bce26781eed109b8aaae2d1f688c134831fdf061",
+		5:      "913772facb72768ccd9db2ab4411296bbe166080",
+		10:     "1aa835eec9a9ac08cc2784d9d29df7fb15409d08",
+		69:     "fd1ba648c9406c0af321cb734eb203c742fff2a3",
+		137:    "fd1da780698b394a352b59e9b0c124f9cf010b67",
+		420:    "810a86b586e5333b453810305f0eabbf0bfb6934",
+		80001:  "13672494a659c31b46a8fa3d6973b7671a1d567b",
+		421613: "d58fd380066628fa92fd8a87831ea744b9ba1d8b",
 	}
 
 	historyDBURI := getHistoryDBURI(t)

--- a/pkg/parsing/impl/validator_test.go
+++ b/pkg/parsing/impl/validator_test.go
@@ -38,29 +38,29 @@ func TestReadRunSQL(t *testing.T) {
 		},
 		{
 			name:       "valid defined rows",
-			query:      "select row1, row2 from zoo_4321 where a = b",
+			query:      "select row1,row2 from zoo_4321 where a=b",
 			expErrType: nil,
 		},
 
 		// Allow joins and sub-queries
 		{
 			name:       "with join",
-			query:      "select * from foo_1 join bar_2 on a = b",
+			query:      "select * from foo_1 join bar_2 on a=b",
 			expErrType: nil,
 		},
 		{
 			name:       "with subselect",
-			query:      "select * from foo_1 where a in (select b from zoo_5)",
+			query:      "select * from foo_1 where a in(select b from zoo_5)",
 			expErrType: nil,
 		},
 		{
 			name:       "column with subquery",
-			query:      "select (select * from bar_2 limit 1) from foo_3",
+			query:      "select(select * from bar_2 limit 1)from foo_3",
 			expErrType: nil,
 		},
 		{
 			name:       "select with complex subqueries in function arguments",
-			query:      `select json_object('name', '#' || rigs.id, 'external_url', 'https://rigs.tableland.xyz/' || rigs.id, 'attributes', json_array(json_object('trait_type', 'Fleet', 'value', rigs.fleet), json_object('trait_type', 'Chassis', 'value', rigs.chassis), json_object('trait_type', 'Wheels', 'value', rigs.wheels), json_object('trait_type', 'Background', 'value', rigs.background), json_object('trait_type', (select name from badges_2 where badges.rig_id = rigs.id and position = 1 limit 1), 'value', (select image from badges_2 where badges.rig_id = rigs.id and position = 1 limit 1)))) from rigs_1`, // nolint
+			query:      `select json_object('name','#'||rigs.id,'external_url','https://rigs.tableland.xyz/'||rigs.id,'attributes',json_array(json_object('trait_type','Fleet','value',rigs.fleet),json_object('trait_type','Chassis','value',rigs.chassis),json_object('trait_type','Wheels','value',rigs.wheels),json_object('trait_type','Background','value',rigs.background),json_object('trait_type',(select name from badges_2 where badges.rig_id=rigs.id and position=1 limit 1),'value',(select image from badges_2 where badges.rig_id=rigs.id and position=1 limit 1))))from rigs_1`, // nolint
 			expErrType: nil,
 		},
 
@@ -574,9 +574,9 @@ func TestCreateTableResult(t *testing.T) {
 			// echo -n bar:INT | shasum -a 256
 			expStructureHash: "5d70b398f938650871dd0d6d421e8d1d0c89fe9ed6c8a817c97e951186da7172",
 			expRawQueries: []rawQueryTableID{
-				{id: 1, rawQuery: "create table my_10_nth_table_1337_1 (bar int) strict"},
-				{id: 42, rawQuery: "create table my_10_nth_table_1337_42 (bar int) strict"},
-				{id: 2929392, rawQuery: "create table my_10_nth_table_1337_2929392 (bar int) strict"},
+				{id: 1, rawQuery: "create table my_10_nth_table_1337_1(bar int)strict"},
+				{id: 42, rawQuery: "create table my_10_nth_table_1337_42(bar int)strict"},
+				{id: 2929392, rawQuery: "create table my_10_nth_table_1337_2929392(bar int)strict"},
 			},
 		},
 		{
@@ -588,8 +588,8 @@ func TestCreateTableResult(t *testing.T) {
 			// echo -n bar:INT | shasum -a 256
 			expStructureHash: "5d70b398f938650871dd0d6d421e8d1d0c89fe9ed6c8a817c97e951186da7172",
 			expRawQueries: []rawQueryTableID{
-				{id: 1, rawQuery: "create table _1337_1 (bar int) strict"},
-				{id: 42, rawQuery: "create table _1337_42 (bar int) strict"},
+				{id: 1, rawQuery: "create table _1337_1(bar int)strict"},
+				{id: 42, rawQuery: "create table _1337_42(bar int)strict"},
 			},
 		},
 		{
@@ -603,9 +603,9 @@ func TestCreateTableResult(t *testing.T) {
 			// echo -n name:TEXT,age:INT,fav_color:TEXT | shasum -a 256
 			expStructureHash: "f45023b189891ad781070ac05374d4e7d7ec7ae007cfd836791c36d609ba7ddd",
 			expRawQueries: []rawQueryTableID{
-				{id: 1, rawQuery: "create table person_1337_1 (name text, age int, fav_color text) strict"},
-				{id: 42, rawQuery: "create table person_1337_42 (name text, age int, fav_color text) strict"},
-				{id: 2929392, rawQuery: "create table person_1337_2929392 (name text, age int, fav_color text) strict"},
+				{id: 1, rawQuery: "create table person_1337_1(name text,age int,fav_color text)strict"},
+				{id: 42, rawQuery: "create table person_1337_42(name text,age int,fav_color text)strict"},
+				{id: 2929392, rawQuery: "create table person_1337_2929392(name text,age int,fav_color text)strict"},
 			},
 		},
 	}
@@ -689,16 +689,16 @@ func TestGetWriteStatements(t *testing.T) {
 			name:  "double update",
 			query: "update foo_1337_100 set a=1;update foo_1337_100 set b=2;",
 			expectedStmts: []string{
-				"update foo_1337_100 set a = 1",
-				"update foo_1337_100 set b = 2",
+				"update foo_1337_100 set a=1",
+				"update foo_1337_100 set b=2",
 			},
 		},
 		{
 			name:  "insert update",
 			query: "insert into foo_1337_1 values (1);update foo_1337_1 set b=2;",
 			expectedStmts: []string{
-				"insert into foo_1337_1 values (1)",
-				"update foo_1337_1 set b = 2",
+				"insert into foo_1337_1 values(1)",
+				"update foo_1337_1 set b=2",
 			},
 		},
 	}
@@ -737,7 +737,7 @@ func TestGetGrantStatementRolesAndPrivileges(t *testing.T) {
 			query:        "grant insert, UPDATE on a_1337_100 to '0xd43c59d5694ec111eb9e986c233200b14249558d';",
 			roles:        []common.Address{common.HexToAddress("0xd43c59d5694ec111eb9e986c233200b14249558d")},
 			privileges:   []tableland.Privilege{tableland.PrivInsert, tableland.PrivUpdate},
-			expectedStmt: "grant insert, update on a_1337_100 to '0xd43c59d5694ec111eb9e986c233200b14249558d'",
+			expectedStmt: "grant insert,update on a_1337_100 to '0xd43c59d5694ec111eb9e986c233200b14249558d'",
 		},
 
 		{
@@ -788,13 +788,13 @@ func TestWriteStatementAddWhereClause(t *testing.T) {
 			name:        "no-where-clause",
 			query:       "UPDATE foo_1337_10 SET id = 1",
 			whereClause: "bar = 1",
-			expQuery:    "update foo_1337_10 set id = 1 where bar = 1",
+			expQuery:    "update foo_1337_10 set id=1 where bar=1",
 		},
 		{
 			name:        "with-where-clause",
 			query:       "update foo_1337_10 set id = 1 where bar = 1",
 			whereClause: "c in (1, 2)",
-			expQuery:    "update foo_1337_10 set id = 1 where bar = 1 and c in (1, 2)",
+			expQuery:    "update foo_1337_10 set id=1 where bar=1 and c in(1,2)",
 		},
 	}
 
@@ -840,7 +840,7 @@ func TestWriteStatementAddReturningClause(t *testing.T) {
 
 		sql, err := ws.GetQuery(nil)
 		require.NoError(t, err)
-		require.Equal(t, "insert into foo_1337_1 values ('bar') returning (rowid)", sql)
+		require.Equal(t, "insert into foo_1337_1 values('bar')returning(rowid)", sql)
 	})
 
 	t.Run("update-add-returning", func(t *testing.T) {
@@ -859,7 +859,7 @@ func TestWriteStatementAddReturningClause(t *testing.T) {
 
 		sql, err := ws.GetQuery(nil)
 		require.NoError(t, err)
-		require.Equal(t, "update foo_1337_1 set foo = 'bar' returning (rowid)", sql)
+		require.Equal(t, "update foo_1337_1 set foo='bar' returning(rowid)", sql)
 	})
 
 	t.Run("delete-add-returning-error", func(t *testing.T) {


### PR DESCRIPTION
# Summary

Bumps the parser to the latest version. This version includes:
- [shorter string output for parsed statements](https://github.com/tablelandnetwork/go-sqlparser/pull/45)
- [fixes bug on upsert walk](https://github.com/tablelandnetwork/go-sqlparser/pull/49)

