### PR TITLE
Replace old table external_url

### DIFF
--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -89,7 +89,7 @@ func (g *GatewayService) GetTableMetadata(ctx context.Context, id tables.TableID
 	chainID, store, err := g.getStore(ctx)
 	if err != nil {
 		return sqlstore.TableMetadata{
-			ExternalURL: fmt.Sprintf("%s/chain/%d/tables/%s", g.extURLPrefix, chainID, id),
+			ExternalURL: fmt.Sprintf("%s/api/v1/tables/%d/%s", g.extURLPrefix, chainID, id),
 			Image:       g.emptyMetadataImage(),
 			Message:     "Chain isn't supported",
 		}, nil
@@ -99,14 +99,14 @@ func (g *GatewayService) GetTableMetadata(ctx context.Context, id tables.TableID
 		if !errors.Is(err, sql.ErrNoRows) {
 			log.Error().Err(err).Msg("error fetching the table")
 			return sqlstore.TableMetadata{
-				ExternalURL: fmt.Sprintf("%s/chain/%d/tables/%s", g.extURLPrefix, chainID, id),
+				ExternalURL: fmt.Sprintf("%s/api/v1/tables/%d/%s", g.extURLPrefix, chainID, id),
 				Image:       g.emptyMetadataImage(),
 				Message:     "Failed to fetch the table",
 			}, nil
 		}
 
 		return sqlstore.TableMetadata{
-			ExternalURL: fmt.Sprintf("%s/chain/%d/tables/%s", g.extURLPrefix, chainID, id),
+			ExternalURL: fmt.Sprintf("%s/api/v1/tables/%d/%s", g.extURLPrefix, chainID, id),
 			Image:       g.emptyMetadataImage(),
 			Message:     "Table not found",
 		}, ErrTableNotFound
@@ -119,7 +119,7 @@ func (g *GatewayService) GetTableMetadata(ctx context.Context, id tables.TableID
 
 	return sqlstore.TableMetadata{
 		Name:         tableName,
-		ExternalURL:  fmt.Sprintf("%s/chain/%d/tables/%s", g.extURLPrefix, table.ChainID, table.ID),
+		ExternalURL:  fmt.Sprintf("%s/api/v1/tables/%d/%s", g.extURLPrefix, table.ChainID, table.ID),
 		Image:        g.getMetadataImage(table.ChainID, table.ID),
 		AnimationURL: g.getAnimationURL(table.ChainID, table.ID),
 		Attributes: []sqlstore.TableMetadataAttribute{

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -39,7 +39,7 @@ func TestGatewayInitialization(t *testing.T) {
 	t.Run("invalid metadata uri", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewGateway(nil, nil, "https://tableland.network/tables", "invalid uri", "")
+		_, err := NewGateway(nil, nil, "https://tableland.network", "invalid uri", "")
 		require.Error(t, err)
 		require.ErrorContains(t, err, "metadata renderer uri could not be parsed")
 	})
@@ -47,7 +47,7 @@ func TestGatewayInitialization(t *testing.T) {
 	t.Run("invalid animation uri", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewGateway(nil, nil, "https://tableland.network/tables", "https://render.tableland.xyz", "invalid uri")
+		_, err := NewGateway(nil, nil, "https://tableland.network", "https://render.tableland.xyz", "invalid uri")
 		require.Error(t, err)
 		require.ErrorContains(t, err, "animation renderer uri could not be parsed")
 	})
@@ -97,7 +97,7 @@ func TestGateway(t *testing.T) {
 	require.NoError(t, err)
 
 	stack := map[tableland.ChainID]sqlstore.SystemStore{1337: store}
-	svc, err := NewGateway(parser, stack, "https://tableland.network/tables", "https://render.tableland.xyz", "")
+	svc, err := NewGateway(parser, stack, "https://tableland.network", "https://render.tableland.xyz", "")
 	require.NoError(t, err)
 	metadata, err := svc.GetTableMetadata(ctx, id)
 	require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestGetMetadata(t *testing.T) {
 		parser, err := parserimpl.New([]string{"system_", "registry", "sqlite_"})
 		require.NoError(t, err)
 
-		svc, err := NewGateway(parser, stack, "https://tableland.network/tables", "", "")
+		svc, err := NewGateway(parser, stack, "https://tableland.network", "", "")
 		require.NoError(t, err)
 
 		metadata, err := svc.GetTableMetadata(ctx, id)
@@ -180,7 +180,7 @@ func TestGetMetadata(t *testing.T) {
 		parser, err := parserimpl.New([]string{"system_", "registry", "sqlite_"})
 		require.NoError(t, err)
 
-		svc, err := NewGateway(parser, stack, "https://tableland.network/tables", "https://render.tableland.xyz", "")
+		svc, err := NewGateway(parser, stack, "https://tableland.network", "https://render.tableland.xyz", "")
 		require.NoError(t, err)
 
 		metadata, err := svc.GetTableMetadata(ctx, id)
@@ -199,7 +199,7 @@ func TestGetMetadata(t *testing.T) {
 		parser, err := parserimpl.New([]string{"system_", "registry", "sqlite_"})
 		require.NoError(t, err)
 
-		svc, err := NewGateway(parser, stack, "https://tableland.network/tables", "https://render.tableland.xyz/", "")
+		svc, err := NewGateway(parser, stack, "https://tableland.network", "https://render.tableland.xyz/", "")
 		require.NoError(t, err)
 
 		metadata, err := svc.GetTableMetadata(ctx, id)
@@ -218,7 +218,7 @@ func TestGetMetadata(t *testing.T) {
 		parser, err := parserimpl.New([]string{"system_", "registry", "sqlite_"})
 		require.NoError(t, err)
 
-		_, err = NewGateway(parser, stack, "https://tableland.network/tables", "foo", "")
+		_, err = NewGateway(parser, stack, "https://tableland.network", "foo", "")
 		require.Error(t, err)
 		require.ErrorContains(t, err, "metadata renderer uri could not be parsed")
 	})
@@ -229,7 +229,7 @@ func TestGetMetadata(t *testing.T) {
 		parser, err := parserimpl.New([]string{"system_", "registry", "sqlite_"})
 		require.NoError(t, err)
 
-		svc, err := NewGateway(parser, stack, "https://tableland.network/tables", "https://render.tableland.xyz", "")
+		svc, err := NewGateway(parser, stack, "https://tableland.network", "https://render.tableland.xyz", "")
 		require.NoError(t, err)
 
 		id, _ := tables.NewTableID("43")
@@ -251,7 +251,7 @@ func TestGetMetadata(t *testing.T) {
 		svc, err := NewGateway(
 			parser,
 			stack,
-			"https://tableland.network/tables",
+			"https://tableland.network",
 			"https://render.tableland.xyz",
 			"https://render.tableland.xyz/anim",
 		)
@@ -292,7 +292,7 @@ func TestQueryConstraints(t *testing.T) {
 		gateway, err := NewGateway(
 			parser,
 			stack,
-			"https://tableland.network/tables",
+			"https://tableland.network",
 			"https://render.tableland.xyz",
 			"https://render.tableland.xyz/anim",
 		)

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -103,7 +103,7 @@ func TestGateway(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "foo_1337_42", metadata.Name)
-	require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
+	require.Equal(t, fmt.Sprintf("https://tableland.network/api/v1/tables/%d/%s", 1337, id), metadata.ExternalURL)
 	require.Equal(t, "https://render.tableland.xyz/1337/42", metadata.Image) //nolint
 	require.Equal(t, "date", metadata.Attributes[0].DisplayType)
 	require.Equal(t, "created", metadata.Attributes[0].TraitType)
@@ -168,7 +168,7 @@ func TestGetMetadata(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, "foo_1337_42", metadata.Name)
-		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
+		require.Equal(t, fmt.Sprintf("https://tableland.network/api/v1/tables/%d/%s", 1337, id), metadata.ExternalURL)
 		require.Equal(t, DefaultMetadataImage, metadata.Image)
 		require.Equal(t, "date", metadata.Attributes[0].DisplayType)
 		require.Equal(t, "created", metadata.Attributes[0].TraitType)
@@ -187,7 +187,7 @@ func TestGetMetadata(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, "foo_1337_42", metadata.Name)
-		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
+		require.Equal(t, fmt.Sprintf("https://tableland.network/api/v1/tables/%d/%s", 1337, id), metadata.ExternalURL)
 		require.Equal(t, "https://render.tableland.xyz/1337/42", metadata.Image)
 		require.Equal(t, "date", metadata.Attributes[0].DisplayType)
 		require.Equal(t, "created", metadata.Attributes[0].TraitType)
@@ -206,7 +206,7 @@ func TestGetMetadata(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, "foo_1337_42", metadata.Name)
-		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
+		require.Equal(t, fmt.Sprintf("https://tableland.network/api/v1/tables/%d/%s", 1337, id), metadata.ExternalURL)
 		require.Equal(t, "https://render.tableland.xyz/1337/42", metadata.Image)
 		require.Equal(t, "date", metadata.Attributes[0].DisplayType)
 		require.Equal(t, "created", metadata.Attributes[0].TraitType)
@@ -237,7 +237,7 @@ func TestGetMetadata(t *testing.T) {
 
 		metadata, err := svc.GetTableMetadata(ctx, id)
 		require.ErrorIs(t, err, ErrTableNotFound)
-		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
+		require.Equal(t, fmt.Sprintf("https://tableland.network/api/v1/tables/%d/%s", 1337, id), metadata.ExternalURL)
 		require.Equal(t, "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nNTEyJyBoZWlnaHQ9JzUxMicgeG1sbnM9J2h0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnJz48cmVjdCB3aWR0aD0nNTEyJyBoZWlnaHQ9JzUxMicgZmlsbD0nIzAwMCcvPjwvc3ZnPg==", metadata.Image) // nolint
 		require.Equal(t, "Table not found", metadata.Message)
 	})
@@ -261,7 +261,7 @@ func TestGetMetadata(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, "foo_1337_42", metadata.Name)
-		require.Equal(t, fmt.Sprintf("https://tableland.network/tables/chain/%d/tables/%s", 1337, id), metadata.ExternalURL)
+		require.Equal(t, fmt.Sprintf("https://tableland.network/api/v1/tables/%d/%s", 1337, id), metadata.ExternalURL)
 		require.Equal(t, "https://render.tableland.xyz/1337/42", metadata.Image)
 		require.Equal(t, "https://render.tableland.xyz/anim/?chain=1337&id=42", metadata.AnimationURL)
 		require.Equal(t, "date", metadata.Attributes[0].DisplayType)

--- a/internal/router/controllers/controller_test.go
+++ b/internal/router/controllers/controller_test.go
@@ -167,11 +167,11 @@ func TestGetTablesByMocked(t *testing.T) {
 
 	t.Run("get table metadata", func(t *testing.T) {
 		t.Parallel()
-		req, err := http.NewRequest("GET", "/chain/1337/tables/100", nil)
+		req, err := http.NewRequest("GET", "/api/v1/tables/1337/100", nil)
 		require.NoError(t, err)
 
 		router := mux.NewRouter()
-		router.HandleFunc("/chain/{chainID}/tables/{tableId}", ctrl.GetTable)
+		router.HandleFunc("/api/v1/tables/{chainID}/{tableId}", ctrl.GetTable)
 
 		rr := httptest.NewRecorder()
 		router.ServeHTTP(rr, req)

--- a/pkg/client/v1/client_test.go
+++ b/pkg/client/v1/client_test.go
@@ -97,7 +97,7 @@ func TestGetTableByID(t *testing.T) {
 
 		table := calls.getTableByID(id)
 		require.NotEmpty(t, fullName, table.Name)
-		require.Equal(t, "https://testnets.tableland.network/chain/1337/tables/1", table.ExternalUrl)
+		require.Equal(t, "https://testnets.tableland.network/api/v1/tables/1337/1", table.ExternalUrl)
 		require.Equal(t, "https://render.tableland.xyz/anim/?chain=1337&id=1", table.AnimationUrl)
 		require.Equal(t, "https://render.tableland.xyz/1337/1", table.Image)
 


### PR DESCRIPTION
This updates the external_url value of table metadata to use the new api endpoints, which is causing issues rendering the table nft on some of the market places. 