### PR TITLE
remove commit hash from binary names

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           submodules: 'true'
       - name: Fetch repo
-        run: git fetch --prune --unshallow      
+        run: git fetch --prune --unshallow
       - name: Install Go
         uses: actions/setup-go@v3
         with:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -91,14 +91,14 @@ archives:
       - api-darwin-arm64
       - api-linux-amd64
       - api-linux-arm64
-    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}-{{ .ShortCommit }}"
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
   - id: api-archive-win
     format: zip
     files:
       - none*
     builds:
       - api-windows-amd64
-    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}-{{ .ShortCommit }}"
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
 
 checksum:
   disable: true


### PR DESCRIPTION
# Summary
This a fix for issue #535 
# Context
When we upgraded the binary build process to include builds for arm64 (i.e. apple silicon), the name template of the binary files was changed to include a short hash of the commit that the build is targeting.
This caused an issue in the build process of the [js-validator repo](https://github.com/tablelandnetwork/js-validator/blob/main/src/build.ts#L64).
The TL;DR; of the js-validator issue is that the script to download and unpack the go-tableland release doesn't have access to the short commit hash that now makes up part of the url where the binary is located.
# Implementation overview
This fix simply removes the commit hash from the file name.  If keeping the commit hash is important, we can close this PR and find a way for the js-validator build script to get the commit hash during the build.

----------------------
- [x]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [x]  Are changes covered by existing tests, or were new tests included?
- [x]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [x]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
