### PR TITLE
updates parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/sethvargo/go-limiter v0.7.2
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.2
-	github.com/tablelandnetwork/sqlparser v0.0.0-20230328132500-785ebca8e351
+	github.com/tablelandnetwork/sqlparser v0.0.0-20230420192826-7c549ca44bf8
 	github.com/textileio/cli v1.0.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.37.0
 	go.opentelemetry.io/otel v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -1296,6 +1296,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a h1:1ur3QoCqvE5f
 github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/tablelandnetwork/sqlparser v0.0.0-20230328132500-785ebca8e351 h1:aHuHicCezduOZVQXPXFM5MJ+h73caB2OUvVjGffzIsc=
 github.com/tablelandnetwork/sqlparser v0.0.0-20230328132500-785ebca8e351/go.mod h1:S+M/v3Q8X+236kQxMQziFcLId2Cscb1LzW06IUVhljE=
+github.com/tablelandnetwork/sqlparser v0.0.0-20230420192826-7c549ca44bf8 h1:mC58HOJfkfPsqetYd4hpCp0ey5qb9/ZkIRZEx+d2b4U=
+github.com/tablelandnetwork/sqlparser v0.0.0-20230420192826-7c549ca44bf8/go.mod h1:S+M/v3Q8X+236kQxMQziFcLId2Cscb1LzW06IUVhljE=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/textileio/cli v1.0.2 h1:qSp/x4d/9SZ93TxhgZnE5okRKqzqHqrzAwKAPjuPw50=
 github.com/textileio/cli v1.0.2/go.mod h1:vTlCvvVyOmXXLwddCcBg3PDavfUsCkRBZoyr6Nu1lkc=

--- a/pkg/eventprocessor/impl/eventprocessor_replayhistory_test.go
+++ b/pkg/eventprocessor/impl/eventprocessor_replayhistory_test.go
@@ -37,12 +37,12 @@ func TestReplayProductionHistory(t *testing.T) {
 
 	expectedStateHashes := map[tableland.ChainID]string{
 		1:      "bce26781eed109b8aaae2d1f688c134831fdf061",
-		5:      "913772facb72768ccd9db2ab4411296bbe166080",
+		5:      "f141373c03aee3a74595538abba81cd1c3755f63",
 		10:     "1aa835eec9a9ac08cc2784d9d29df7fb15409d08",
 		69:     "fd1ba648c9406c0af321cb734eb203c742fff2a3",
 		137:    "fd1da780698b394a352b59e9b0c124f9cf010b67",
-		420:    "810a86b586e5333b453810305f0eabbf0bfb6934",
-		80001:  "13672494a659c31b46a8fa3d6973b7671a1d567b",
+		420:    "639dda72b6e4a5a8ef7ceb2b734e0b6ecc241407",
+		80001:  "f5bc53afc7525e9ff1f337bad8e9d4e9cb1ad111",
 		421613: "d58fd380066628fa92fd8a87831ea744b9ba1d8b",
 	}
 


### PR DESCRIPTION
# Summary

Updates the parser 

# Context

When an identifier or alias had a dot, the stringification of the AST was producing an invalid statement.
See https://github.com/tablelandnetwork/go-sqlparser/pull/52

