### PR TITLE
fixes table ids duplication in receipts

### DIFF
--- a/pkg/eventprocessor/eventfeed/impl/eventfeed.go
+++ b/pkg/eventprocessor/eventfeed/impl/eventfeed.go
@@ -151,6 +151,10 @@ func (ef *EventFeed) Start(
 			// sideffects.
 			toHeight := h.Number.Int64() - int64(ef.config.MinBlockChainDepth)
 			if toHeight < fromHeight {
+				ef.log.Warn().
+					Int64("from_height", fromHeight).
+					Int64("to_height", toHeight).
+					Msgf("from_height bigger than to_height")
 				break
 			}
 

--- a/pkg/eventprocessor/impl/executor/impl/executor_test.go
+++ b/pkg/eventprocessor/impl/executor/impl/executor_test.go
@@ -109,6 +109,7 @@ func TestMultiEventTxnBlock(t *testing.T) {
 		require.Nil(t, res.Error)
 		require.Nil(t, res.ErrorEventIdx)
 		require.Equal(t, eventCreateTable.TableId.Int64(), res.TableID.ToBigInt().Int64())
+		require.Equal(t, []tables.TableID{tables.TableID(*big.NewInt(100))}, res.TableIDs)
 	}
 	// Txn 2
 	{

--- a/pkg/eventprocessor/impl/executor/impl/txnscope.go
+++ b/pkg/eventprocessor/impl/executor/impl/txnscope.go
@@ -56,7 +56,7 @@ func (ts *txnScope) executeTxnEvents(
 	var res eventExecutionResult
 	var err error
 
-	tableIDs := make([]tables.TableID, 0)
+	tableIDs, tableIDsMap := make([]tables.TableID, 0), make(map[string]struct{})
 	for idx, event := range evmTxn.Events {
 		switch event := event.(type) {
 		case *ethereum.ContractRunSQL:
@@ -110,7 +110,10 @@ func (ts *txnScope) executeTxnEvents(
 		}
 
 		if res.TableID != nil {
-			tableIDs = append(tableIDs, *res.TableID)
+			if _, ok := tableIDsMap[(*res.TableID).String()]; !ok {
+				tableIDs = append(tableIDs, *res.TableID)
+				tableIDsMap[(*res.TableID).String()] = struct{}{}
+			}
 		}
 	}
 


### PR DESCRIPTION
# Summary

The `table_ids` were duplicated in the receipt in the case of multiple events from the same table. 
This PR fixes code to avoid that but does not fix the data. That will be done with an update directly in the database.

