### PR TITLE
Add healthbot config for calibration

### DIFF
--- a/cmd/healthbot/config.go
+++ b/cmd/healthbot/config.go
@@ -31,6 +31,7 @@ type ChainConfig struct {
 	WalletPrivateKey string
 	AlchemyAPIKey    string
 	AnkrAPIKey       string
+	GlifAPIKey       string
 	Probe            struct {
 		CheckInterval  string `default:"15s"`
 		ReceiptTimeout string `default:"20s"`

--- a/cmd/healthbot/main.go
+++ b/cmd/healthbot/main.go
@@ -62,7 +62,7 @@ func main() {
 		opts := []clientV1.NewClientOption{clientV1.NewClientChain(chain)}
 		if chain.ID == 314159 {
 			// Glif API key is empty string because currently we are using the free tier (public node)
-			opts = append(opts, clientV1.NewClientGlifAPIKey(""))
+			opts = append(opts, clientV1.NewClientGlifAPIKey(chainCfg.GlifAPIKey))
 		} else {
 			opts = append(opts, clientV1.NewClientAlchemyAPIKey(chainCfg.AlchemyAPIKey))
 		}

--- a/docker/deployed/testnet/healthbot/config.json
+++ b/docker/deployed/testnet/healthbot/config.json
@@ -30,6 +30,16 @@
                 "ReceiptTimeout": "40s",
                 "Tablename": "${HEALTHBOT_POLYGON_MUMBAI_TABLE}"
             }
+        },
+        {
+            "ChainID": 314159,
+            "WalletPrivateKey": "${HEALTHBOT_FILECOIN_CALIBRATION_PRIVATE_KEY}",
+            "GlifAPIKey": "${HEALTHBOT_GLIF_FILECOIN_CALIBRATION_API_KEY}",
+            "Probe": {
+                "CheckInterval": "5m",
+                "ReceiptTimeout": "300s",
+                "Tablename": "${HEALTHBOT_FILECOIN_CALIBRATION_TABLE}"
+            }
         }
     ]
 }


### PR DESCRIPTION
# Summary

Follow up PR to #580 

It adds the `healthbot` configuration for the calibration net. Due to the 2k block history constraint, we needed to deploy the `healthbot` table manually after deploying the validator. 


- [x]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [x]  Are changes covered by existing tests, or were new tests included?
- [x]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [x]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
- [x]  Required ENV vars in the testnet
