### PR TITLE
[got-111] change empty /query status to 200

### DIFF
--- a/internal/router/controllers/controller.go
+++ b/internal/router/controllers/controller.go
@@ -282,11 +282,11 @@ func (c *Controller) runReadRequest(
 		_ = json.NewEncoder(rw).Encode(errors.ServiceError{Message: err.Error()})
 		return nil, false
 	}
-	if len(res.Rows) == 0 {
+	/* if len(res.Rows) == 0 {
 		rw.WriteHeader(http.StatusNotFound)
 		_ = json.NewEncoder(rw).Encode(errors.ServiceError{Message: "Row not found"})
 		return nil, false
-	}
+	} */
 	return res, true
 }
 

--- a/internal/router/controllers/controller.go
+++ b/internal/router/controllers/controller.go
@@ -282,11 +282,7 @@ func (c *Controller) runReadRequest(
 		_ = json.NewEncoder(rw).Encode(errors.ServiceError{Message: err.Error()})
 		return nil, false
 	}
-	/* if len(res.Rows) == 0 {
-		rw.WriteHeader(http.StatusNotFound)
-		_ = json.NewEncoder(rw).Encode(errors.ServiceError{Message: "Row not found"})
-		return nil, false
-	} */
+
 	return res, true
 }
 


### PR DESCRIPTION
# Summary

This PR ensures that we don't return 404 from the Gateway API if the table is empty i.e. there are no rows in the table.

# Context

[GOT-111] [JST-28]



# Checklist

- [ ]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [x]  Are changes covered by existing tests, or were new tests included?
- [x]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [x]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
