### PR TITLE
Reformat webhooks

### DIFF
--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -85,7 +85,8 @@
             },
             "EventProcessor": {
                 "BlockFailedExecutionBackoff": "10s",
-                "DedupExecutedTxns": true
+                "DedupExecutedTxns": true,
+                "WebhookURL": "https://discord.com/api/webhooks/${VALIDATOR_DISCORD_WEBHOOK_ID}/${VALIDATOR_DISCORD_WEBHOOK_TOKEN}"
             },
             "HashCalculationStep": 150
         },
@@ -161,7 +162,8 @@
             },
             "EventProcessor": {
                 "BlockFailedExecutionBackoff": "10s",
-                "DedupExecutedTxns": true
+                "DedupExecutedTxns": true,
+                "WebhookURL": "https://discord.com/api/webhooks/${VALIDATOR_DISCORD_WEBHOOK_ID}/${VALIDATOR_DISCORD_WEBHOOK_TOKEN}"
             },
             "HashCalculationStep": 60
         }

--- a/pkg/eventprocessor/impl/webhook.go
+++ b/pkg/eventprocessor/impl/webhook.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	logger "github.com/rs/zerolog/log"
-	"github.com/textileio/go-tableland/internal/tableland"	
+	"github.com/textileio/go-tableland/internal/tableland"
 	"github.com/textileio/go-tableland/pkg/eventprocessor"
 )
 

--- a/pkg/eventprocessor/impl/webhook.go
+++ b/pkg/eventprocessor/impl/webhook.go
@@ -8,9 +8,12 @@ import (
 	"html/template"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	logger "github.com/rs/zerolog/log"
+	"github.com/textileio/go-tableland/internal/tableland"	
 	"github.com/textileio/go-tableland/pkg/eventprocessor"
 )
 
@@ -19,9 +22,9 @@ const contentTemplate = `
 {{ if .Error }}
 **Error processing Tableland event:**
 
-Chain ID: {{ .ChainID }}
+Chain ID: [{{ .ChainID }}]({{ .TBLDocsURL }})
 Block number: {{ .BlockNumber }}
-Transaction hash: {{ .TxnHash }}
+Transaction hash: [{{ .TxnHash }}]({{ .TxnURL }})
 Table IDs: {{ .TableIDs }}
 Error: **{{ .Error }}**
 Error event index: {{ .ErrorEventIdx }}
@@ -29,9 +32,9 @@ Error event index: {{ .ErrorEventIdx }}
 {{ else }}
 **Tableland event processed successfully:**
 
-Chain ID: {{ .ChainID }}
+Chain ID: [{{ .ChainID }}]({{ .TBLDocsURL }})
 Block number: {{ .BlockNumber }}
-Transaction hash: {{ .TxnHash }}
+Transaction hash: [{{ .TxnHash }}]({{ .TxnURL }})
 Table IDs: {{ .TableIDs }}
 
 {{ end }}
@@ -76,6 +79,112 @@ func sendWebhookRequest(ctx context.Context, url string, body interface{}) error
 	return nil
 }
 
+type chain struct {
+	ID               int64
+	Name             string
+	ContractAddr     common.Address
+	TBLDocsURL       string
+	BlockExplorerURL string
+}
+
+var chains = map[int64]chain{
+	1: {
+		ID:               1,
+		Name:             "Ethereum",
+		ContractAddr:     common.HexToAddress("0x012969f7e3439a9B04025b5a049EB9BAD82A8C12"),
+		TBLDocsURL:       "https://docs.tableland.xyz/fundamentals/chains/ethereum",
+		BlockExplorerURL: "https://etherscan.io",
+	},
+	10: {
+		ID:               10,
+		Name:             "Optimism",
+		ContractAddr:     common.HexToAddress("0xfad44BF5B843dE943a09D4f3E84949A11d3aa3e6"),
+		TBLDocsURL:       "https://docs.tableland.xyz/fundamentals/chains/optimism",
+		BlockExplorerURL: "https://optimistic.etherscan.io",
+	},
+	137: {
+		ID:               137,
+		Name:             "Polygon",
+		ContractAddr:     common.HexToAddress("0x5c4e6A9e5C1e1BF445A062006faF19EA6c49aFeA"),
+		TBLDocsURL:       "https://docs.tableland.xyz/fundamentals/chains/polygon",
+		BlockExplorerURL: "https://polygonscan.com",
+	},
+	42161: {
+		ID:               42161,
+		Name:             "Arbitrum",
+		ContractAddr:     common.HexToAddress("0x9aBd75E8640871A5a20d3B4eE6330a04c962aFfd"),
+		TBLDocsURL:       "https://docs.tableland.xyz/fundamentals/chains/arbitrum",
+		BlockExplorerURL: "https://arbiscan.io",
+	},
+	42170: {
+		ID:               42170,
+		Name:             "Arbitrum Nova",
+		ContractAddr:     common.HexToAddress("0x1a22854c5b1642760a827f20137a67930ae108d2"),
+		TBLDocsURL:       "https://docs.tableland.xyz/fundamentals/chains/arbitrum",
+		BlockExplorerURL: "https://nova.arbiscan.io",
+	},
+	314: {
+		ID:               314,
+		Name:             "Filecoin",
+		ContractAddr:     common.HexToAddress("0x59EF8Bf2d6c102B4c42AEf9189e1a9F0ABfD652d"),
+		TBLDocsURL:       "https://docs.tableland.xyz/fundamentals/chains/Filecoin",
+		BlockExplorerURL: "https://filfox.info/en",
+	},
+	5: {
+		ID:               5,
+		Name:             "Ethereum Goerli",
+		ContractAddr:     common.HexToAddress("0xDA8EA22d092307874f30A1F277D1388dca0BA97a"),
+		TBLDocsURL:       "https://docs.tableland.xyz/fundamentals/chains/ethereum",
+		BlockExplorerURL: "https://goerli.etherscan.io",
+	},
+	11155111: {
+		ID:               11155111,
+		Name:             "Ethereum Sepolia",
+		ContractAddr:     common.HexToAddress("0xc50C62498448ACc8dBdE43DA77f8D5D2E2c7597D"),
+		TBLDocsURL:       "https://docs.tableland.xyz/fundamentals/chains/ethereum",
+		BlockExplorerURL: "https://sepolia.etherscan.io",
+	},
+	420: {
+		ID:               420,
+		Name:             "Optimism Goerli",
+		ContractAddr:     common.HexToAddress("0xC72E8a7Be04f2469f8C2dB3F1BdF69A7D516aBbA"),
+		TBLDocsURL:       "https://docs.tableland.xyz/fundamentals/chains/optimism",
+		BlockExplorerURL: "https://blockscout.com/optimism/goerli/",
+	},
+	421613: {
+		ID:               421613,
+		Name:             "Arbitrum Goerli",
+		ContractAddr:     common.HexToAddress("0x033f69e8d119205089Ab15D340F5b797732f646b"),
+		TBLDocsURL:       "https://docs.tableland.xyz/fundamentals/chains/arbitrum",
+		BlockExplorerURL: "https://goerli-rollup-explorer.arbitrum.io/",
+	},
+	314159: {
+		ID:               314159,
+		Name:             "Filecoin Calibration",
+		ContractAddr:     common.HexToAddress("0x030BCf3D50cad04c2e57391B12740982A9308621"),
+		TBLDocsURL:       "https://docs.tableland.xyz/fundamentals/chains/Filecoin",
+		BlockExplorerURL: "https://calibration.filfox.info/en",
+	},
+	80001: {
+		ID:               80001,
+		Name:             "Polygon Mumbai",
+		ContractAddr:     common.HexToAddress("0x4b48841d4b32C4650E4ABc117A03FE8B51f38F68"),
+		TBLDocsURL:       "https://docs.tableland.xyz/fundamentals/chains/polygon",
+		BlockExplorerURL: "https://mumbai.polygonscan.com",
+	},
+}
+
+type webhookContentData struct {
+	ChainID       tableland.ChainID
+	TBLDocsURL    string
+	BlockNumber   int64
+	TxnHash       string
+	TxnURL        string
+	TableIDs      string
+	Error         *string
+	ErrorEventIdx *int
+}
+
 // Content function to return the formatted content for the webhook.
 func content(r eventprocessor.Receipt) (string, error) {
 	var c bytes.Buffer
@@ -83,7 +192,34 @@ func content(r eventprocessor.Receipt) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to parse template: %v", err)
 	}
-	err = tmpl.Execute(&c, r)
+
+	// TODO: refactor into a function
+	var tableNFTURLs []string
+	for _, tableID := range r.TableIDs {
+		// No NFT view available for Filecoin explorers
+		if r.ChainID == 314 || r.ChainID == 314159 {
+			tableNFTURLs = append(tableNFTURLs, tableID.String())
+		} else {
+			blockExplorerURL := chains[int64(r.ChainID)].BlockExplorerURL
+			contractAddr := chains[int64(r.ChainID)].ContractAddr
+			tableNFTURLs = append(tableNFTURLs,
+				fmt.Sprintf("[%s](%s/nft/%s/%s)", tableID.String(),
+					blockExplorerURL, contractAddr, tableID.String()))
+		}
+	}
+
+	txnURL := chains[int64(r.ChainID)].BlockExplorerURL + "/tx/" + r.TxnHash
+	docsURL := chains[int64(r.ChainID)].TBLDocsURL
+	err = tmpl.Execute(&c, webhookContentData{
+		ChainID:       r.ChainID,
+		TBLDocsURL:    docsURL,
+		BlockNumber:   r.BlockNumber,
+		TxnHash:       r.TxnHash,
+		TxnURL:        txnURL,
+		TableIDs:      strings.Join(tableNFTURLs, ", "),
+		Error:         r.Error,
+		ErrorEventIdx: r.ErrorEventIdx,
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to execute template: %v", err)
 	}

--- a/pkg/eventprocessor/impl/webhook_test.go
+++ b/pkg/eventprocessor/impl/webhook_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"	
+	"github.com/stretchr/testify/assert"
 	"github.com/textileio/go-tableland/pkg/eventprocessor"
 	"github.com/textileio/go-tableland/pkg/tables"
 )

--- a/pkg/eventprocessor/impl/webhook_test.go
+++ b/pkg/eventprocessor/impl/webhook_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"	
 	"github.com/textileio/go-tableland/pkg/eventprocessor"
 	"github.com/textileio/go-tableland/pkg/tables"
 )
@@ -22,6 +22,10 @@ func TestExecuteWebhook(t *testing.T) {
 		}
 		mockTableIDs = append(mockTableIDs, tID)
 	}
+
+	ethChain := chains[1]
+	filChain := chains[314]
+	filCalibChain := chains[314159]
 
 	testCases := []struct {
 		name           string
@@ -41,11 +45,64 @@ func TestExecuteWebhook(t *testing.T) {
 				},
 			},
 			expectedOutput: []string{
-				"\n\n**Tableland event processed successfully:**\n\n" +
-					"Chain ID: 1\n" +
-					"Block number: 1\n" +
-					"Transaction hash: hash1\n" +
-					"Table IDs: 0\n\n\n",
+				fmt.Sprintf(
+					"\n\n**Tableland event processed successfully:**\n\n"+
+						"Chain ID: [1](%s)\n"+
+						"Block number: 1\n"+
+						"Transaction hash: [hash1](%s)\n"+
+						"Table IDs: [0](%s)\n\n\n",
+					ethChain.TBLDocsURL,
+					ethChain.BlockExplorerURL+"/tx/hash1",
+					ethChain.BlockExplorerURL+"/nft/"+ethChain.ContractAddr.String()+"/0",
+				),
+			},
+		},
+		{
+			name: "single receipt Filecoin",
+			receipts: []eventprocessor.Receipt{
+				{
+					BlockNumber:   1,
+					ChainID:       314,
+					TxnHash:       "hash1",
+					Error:         nil,
+					ErrorEventIdx: nil,
+					TableIDs:      mockTableIDs[:1],
+				},
+			},
+			expectedOutput: []string{
+				fmt.Sprintf(
+					"\n\n**Tableland event processed successfully:**\n\n"+
+						"Chain ID: [314](%s)\n"+
+						"Block number: 1\n"+
+						"Transaction hash: [hash1](%s)\n"+
+						"Table IDs: 0\n\n\n",
+					filChain.TBLDocsURL,
+					filChain.BlockExplorerURL+"/tx/hash1",
+				),
+			},
+		},
+		{
+			name: "single receipt Filecoin Testnet",
+			receipts: []eventprocessor.Receipt{
+				{
+					BlockNumber:   1,
+					ChainID:       314159,
+					TxnHash:       "hash1",
+					Error:         nil,
+					ErrorEventIdx: nil,
+					TableIDs:      mockTableIDs[:1],
+				},
+			},
+			expectedOutput: []string{
+				fmt.Sprintf(
+					"\n\n**Tableland event processed successfully:**\n\n"+
+						"Chain ID: [314159](%s)\n"+
+						"Block number: 1\n"+
+						"Transaction hash: [hash1](%s)\n"+
+						"Table IDs: 0\n\n\n",
+					filCalibChain.TBLDocsURL,
+					filCalibChain.BlockExplorerURL+"/tx/hash1",
+				),
 			},
 		},
 		{
@@ -69,16 +126,29 @@ func TestExecuteWebhook(t *testing.T) {
 				},
 			},
 			expectedOutput: []string{
-				"\n\n**Tableland event processed successfully:**\n\n" +
-					"Chain ID: 1\n" +
-					"Block number: 1\n" +
-					"Transaction hash: hash1\n" +
-					"Table IDs: 0,1\n\n\n",
-				"\n\n**Tableland event processed successfully:**\n\n" +
-					"Chain ID: 1\n" +
-					"Block number: 2\n" +
-					"Transaction hash: hash2\n" +
-					"Table IDs: 0,1,2\n\n\n",
+				fmt.Sprintf(
+					"\n\n**Tableland event processed successfully:**\n\n"+
+						"Chain ID: [1](%s)\n"+
+						"Block number: 1\n"+
+						"Transaction hash: [hash1](%s)\n"+
+						"Table IDs: [0](%s), [1](%s)\n\n\n",
+					ethChain.TBLDocsURL,
+					ethChain.BlockExplorerURL+"/tx/hash1",
+					ethChain.BlockExplorerURL+"/nft/"+ethChain.ContractAddr.String()+"/0",
+					ethChain.BlockExplorerURL+"/nft/"+ethChain.ContractAddr.String()+"/1",
+				),
+				fmt.Sprintf(
+					"\n\n**Tableland event processed successfully:**\n\n"+
+						"Chain ID: [1](%s)\n"+
+						"Block number: 2\n"+
+						"Transaction hash: [hash2](%s)\n"+
+						"Table IDs: [0](%s), [1](%s), [2](%s)\n\n\n",
+					ethChain.TBLDocsURL,
+					ethChain.BlockExplorerURL+"/tx/hash2",
+					ethChain.BlockExplorerURL+"/nft/"+ethChain.ContractAddr.String()+"/0",
+					ethChain.BlockExplorerURL+"/nft/"+ethChain.ContractAddr.String()+"/1",
+					ethChain.BlockExplorerURL+"/nft/"+ethChain.ContractAddr.String()+"/2",
+				),
 			},
 		},
 		{
@@ -94,13 +164,18 @@ func TestExecuteWebhook(t *testing.T) {
 				},
 			},
 			expectedOutput: []string{
-				"\n\n**Error processing Tableland event:**\n\n" +
-					"Chain ID: 1\n" +
-					"Block number: 1\n" +
-					"Transaction hash: hash1\n" +
-					"Table IDs: 0\n" +
-					"Error: **error1**\n" +
-					"Error event index: 1\n\n\n",
+				fmt.Sprintf(
+					"\n\n**Error processing Tableland event:**\n\n"+
+						"Chain ID: [1](%s)\n"+
+						"Block number: 1\n"+
+						"Transaction hash: [hash1](%s)\n"+
+						"Table IDs: [0](%s)\n"+
+						"Error: **error1**\n"+
+						"Error event index: 1\n\n\n",
+					ethChain.TBLDocsURL,
+					ethChain.BlockExplorerURL+"/tx/hash1",
+					ethChain.BlockExplorerURL+"/nft/"+ethChain.ContractAddr.String()+"/0",
+				),
 			},
 		},
 	}


### PR DESCRIPTION
### Summary

Adds more context to webhooks content by adding hyperlinks for transactions, table ids and chain ids. Fixes GOT-108


### Implementation overview

To add links to the tableland docs, and block explorers I have stored these links in the webhooks package against their corresponding chain ids. 


- [ ]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [ ]  Are changes covered by existing tests, or were new tests included?
- [ ]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [ ]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
