### PR TITLE
allows authorized clients to bypass rate limiter

### DIFF
--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -51,7 +51,7 @@ type HTTPConfig struct {
 
 	RateLimInterval       string `default:"1s"`
 	MaxRequestPerInterval uint64 `default:"10"`
-	AllowList             string `default:""`
+	AllowList             string `default:""` // separated list of IPs (e.g. 127.0.0.1,192.168.0.1)
 }
 
 // GatewayConfig contains configuration for the Gateway.

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -51,7 +51,7 @@ type HTTPConfig struct {
 
 	RateLimInterval       string `default:"1s"`
 	MaxRequestPerInterval uint64 `default:"10"`
-	AllowList             string `default:""` // separated list of IPs (e.g. 127.0.0.1,192.168.0.1)
+	APIKey                string `default:""` // if client passes the key it will not be affected by rate limiter
 }
 
 // GatewayConfig contains configuration for the Gateway.

--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -51,6 +51,7 @@ type HTTPConfig struct {
 
 	RateLimInterval       string `default:"1s"`
 	MaxRequestPerInterval uint64 `default:"10"`
+	AllowList             string `default:""`
 }
 
 // GatewayConfig contains configuration for the Gateway.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -460,14 +460,12 @@ func createAPIServer(
 		return nil, fmt.Errorf("parsing http ratelimiter interval: %s", err)
 	}
 
-	allowList := strings.Split(httpConfig.AllowList, ",")
-
 	router, err := router.ConfiguredRouter(
 		g,
 		httpConfig.MaxRequestPerInterval,
 		rateLimInterval,
 		supportedChainIDs,
-		allowList,
+		httpConfig.APIKey,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("configuring router: %s", err)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -460,11 +460,14 @@ func createAPIServer(
 		return nil, fmt.Errorf("parsing http ratelimiter interval: %s", err)
 	}
 
+	allowList := strings.Split(httpConfig.AllowList, ",")
+
 	router, err := router.ConfiguredRouter(
 		g,
 		httpConfig.MaxRequestPerInterval,
 		rateLimInterval,
 		supportedChainIDs,
+		allowList,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("configuring router: %s", err)

--- a/docker/deployed/mainnet/api/config.json
+++ b/docker/deployed/mainnet/api/config.json
@@ -4,7 +4,7 @@
         "Port": "8080",
         "RateLimInterval": "1s",
         "MaxRequestPerInterval": 10,
-        "AllowList" : "${HTTP_RATE_LIMITER_ALLOWLIST}", 
+        "ApiKey" : "${HTTP_RATE_LIMITER_API_KEY}", 
         "TLSCert": "${VALIDATOR_TLS_CERT}",
         "TLSKey": "${VALIDATOR_TLS_KEY}"
     },

--- a/docker/deployed/mainnet/api/config.json
+++ b/docker/deployed/mainnet/api/config.json
@@ -4,6 +4,7 @@
         "Port": "8080",
         "RateLimInterval": "1s",
         "MaxRequestPerInterval": 10,
+        "AllowList" : "${HTTP_RATE_LIMITER_ALLOWLIST}", 
         "TLSCert": "${VALIDATOR_TLS_CERT}",
         "TLSKey": "${VALIDATOR_TLS_KEY}"
     },

--- a/docker/deployed/staging/api/config.json
+++ b/docker/deployed/staging/api/config.json
@@ -3,7 +3,7 @@
     "Port": "8080",
     "RateLimInterval": "1s",
     "MaxRequestPerInterval": 10,
-    "AllowList" : "${HTTP_RATE_LIMITER_ALLOWLIST}", 
+    "ApiKey" : "${HTTP_RATE_LIMITER_API_KEY}", 
     "TLSCert": "${VALIDATOR_TLS_CERT}",
     "TLSKey": "${VALIDATOR_TLS_KEY}"
   },

--- a/docker/deployed/staging/api/config.json
+++ b/docker/deployed/staging/api/config.json
@@ -3,6 +3,7 @@
     "Port": "8080",
     "RateLimInterval": "1s",
     "MaxRequestPerInterval": 10,
+    "AllowList" : "${HTTP_RATE_LIMITER_ALLOWLIST}", 
     "TLSCert": "${VALIDATOR_TLS_CERT}",
     "TLSKey": "${VALIDATOR_TLS_KEY}"
   },

--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -4,6 +4,7 @@
         "Port": "8080",
         "RateLimInterval": "1s",
         "MaxRequestPerInterval": 10,
+        "AllowList" : "${HTTP_RATE_LIMITER_ALLOWLIST}", 
         "TLSCert": "${VALIDATOR_TLS_CERT}",
         "TLSKey": "${VALIDATOR_TLS_KEY}"
     },
@@ -51,25 +52,6 @@
         "ChainStackCollectFrequency": "15m"
     },
     "Chains": [
-        {
-            "Name": "Ethereum Goerli",
-            "ChainID": 5,
-            "Registry": {
-                "EthEndpoint": "wss://eth-goerli.alchemyapi.io/v2/${VALIDATOR_ALCHEMY_ETHEREUM_GOERLI_API_KEY}",
-                "ContractAddress": "0xDA8EA22d092307874f30A1F277D1388dca0BA97a"
-            },
-            "EventFeed": {
-                "ChainAPIBackoff": "15s",
-                "NewBlockPollFreq": "10s",
-                "MinBlockDepth": 1,
-                "PersistEvents": true
-            },
-            "EventProcessor": {
-                "BlockFailedExecutionBackoff": "10s",
-                "DedupExecutedTxns": true
-            },
-            "HashCalculationStep": 150
-        },
         {
             "Name": "Ethereum Sepolia",
             "ChainID": 11155111,

--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -4,7 +4,7 @@
         "Port": "8080",
         "RateLimInterval": "1s",
         "MaxRequestPerInterval": 10,
-        "AllowList" : "${HTTP_RATE_LIMITER_ALLOWLIST}", 
+        "ApiKey" : "${HTTP_RATE_LIMITER_API_KEY}", 
         "TLSCert": "${VALIDATOR_TLS_CERT}",
         "TLSKey": "${VALIDATOR_TLS_KEY}"
     },

--- a/internal/router/middlewares/ratelim.go
+++ b/internal/router/middlewares/ratelim.go
@@ -106,8 +106,8 @@ func (m *middleware) Handle(next http.Handler) http.Handler {
 			return
 		}
 
-		// skip rate limiting checks if secret key is provided
-		if key := r.Header.Get("Secret-Key"); key != "" && m.apiKey != "" {
+		// skip rate limiting checks if api key is provided
+		if key := r.Header.Get("Api-Key"); key != "" && m.apiKey != "" {
 			if strings.EqualFold(key, m.apiKey) {
 				next.ServeHTTP(w, r)
 				return

--- a/internal/router/middlewares/ratelim.go
+++ b/internal/router/middlewares/ratelim.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/sethvargo/go-limiter"
 	"github.com/sethvargo/go-limiter/httplimit"
 	"github.com/sethvargo/go-limiter/memorystore"
 )
@@ -20,8 +22,9 @@ type RateLimiterConfig struct {
 // RateLimiterRouteConfig specifies the maximum request per interval, and
 // interval length for a rate limiting rule.
 type RateLimiterRouteConfig struct {
-	MaxRPI   uint64
-	Interval time.Duration
+	MaxRPI    uint64
+	Interval  time.Duration
+	AllowList []string
 }
 
 // RateLimitController creates a new middleware to rate limit requests.
@@ -47,7 +50,7 @@ func RateLimitController(cfg RateLimiterConfig) (mux.MiddlewareFunc, error) {
 	}, nil
 }
 
-func createRateLimiter(cfg RateLimiterRouteConfig, kf httplimit.KeyFunc) (*httplimit.Middleware, error) {
+func createRateLimiter(cfg RateLimiterRouteConfig, kf httplimit.KeyFunc) (*middleware, error) {
 	defaultStore, err := memorystore.New(&memorystore.Config{
 		Tokens:   cfg.MaxRPI,
 		Interval: cfg.Interval,
@@ -55,11 +58,12 @@ func createRateLimiter(cfg RateLimiterRouteConfig, kf httplimit.KeyFunc) (*httpl
 	if err != nil {
 		return nil, fmt.Errorf("creating default memory: %s", err)
 	}
-	m, err := httplimit.NewMiddleware(defaultStore, kf)
-	if err != nil {
-		return nil, fmt.Errorf("creating default httplimiter: %s", err)
-	}
-	return m, nil
+
+	return &middleware{
+		store:     defaultStore,
+		keyFunc:   kf,
+		allowlist: cfg.AllowList,
+	}, nil
 }
 
 func extractClientIP(r *http.Request) (string, error) {
@@ -76,4 +80,63 @@ func extractClientIP(r *http.Request) (string, error) {
 		return "", fmt.Errorf("getting ip from remote addr: %s", err)
 	}
 	return ip, nil
+}
+
+type middleware struct {
+	store   limiter.Store
+	keyFunc httplimit.KeyFunc
+
+	// list of ip addresses not affected by rate limiter
+	allowlist []string
+}
+
+// Handle returns the HTTP handler as a middleware. This handler calls Take() on
+// the store and sets the common rate limiting headers. If the take is
+// successful, the remaining middleware is called. If take is unsuccessful, the
+// middleware chain is halted and the function renders a 429 to the caller with
+// metadata about when it's safe to retry.
+func (m *middleware) Handle(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		// Call the key function - if this fails, it's an internal server error.
+		key, err := m.keyFunc(r)
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
+		// skip rate limiting checks if key is in allowlist
+		for _, ip := range m.allowlist {
+			if strings.EqualFold(key, ip) {
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		// Take from the store.
+		limit, remaining, reset, ok, err := m.store.Take(ctx, key)
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
+		resetTime := time.Unix(0, int64(reset)).UTC().Format(time.RFC1123)
+
+		// Set headers (we do this regardless of whether the request is permitted).
+		w.Header().Set("X-RateLimit-Limit", strconv.FormatUint(limit, 10))
+		w.Header().Set("X-RateLimit-Remaining", strconv.FormatUint(remaining, 10))
+		w.Header().Set("X-RateLimit-Reset", resetTime)
+
+		// Fail if there were no tokens remaining.
+		if !ok {
+			w.Header().Set("Retry-After", resetTime)
+			http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+			return
+		}
+
+		// If we got this far, we're allowed to continue, so call the next middleware
+		// in the stack to continue processing.
+		next.ServeHTTP(w, r)
+	})
 }

--- a/internal/router/middlewares/ratelim_test.go
+++ b/internal/router/middlewares/ratelim_test.go
@@ -58,7 +58,7 @@ func TestLimit1IP(t *testing.T) {
 				}
 
 				if tc.allow {
-					r.Header.Set("Secret-Key", "MYSECRETKEY")
+					r.Header.Set("Api-Key", "MYSECRETKEY")
 					cfg.Default.APIKey = "MYSECRETKEY"
 				}
 

--- a/internal/router/middlewares/ratelim_test.go
+++ b/internal/router/middlewares/ratelim_test.go
@@ -31,7 +31,7 @@ func TestLimit1IP(t *testing.T) {
 		{name: "block-me", callRPS: 1000, limitRPS: 500, forwardedFor: false},
 
 		{name: "allow-me", callRPS: 1000, limitRPS: 500, forwardedFor: false, allow: true},
-		{name: "forwareded-allow-me", callRPS: 1000, limitRPS: 500, forwardedFor: true, allow: true},
+		{name: "forwarded-allow-me", callRPS: 1000, limitRPS: 500, forwardedFor: true, allow: true},
 	}
 
 	for _, tc := range tests {
@@ -58,7 +58,8 @@ func TestLimit1IP(t *testing.T) {
 				}
 
 				if tc.allow {
-					cfg.Default.AllowList = []string{ip}
+					r.Header.Set("Secret-Key", "MYSECRETKEY")
+					cfg.Default.APIKey = "MYSECRETKEY"
 				}
 
 				rlcm, err := RateLimitController(cfg)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -19,7 +19,7 @@ func ConfiguredRouter(
 	maxRPI uint64,
 	rateLimInterval time.Duration,
 	supportedChainIDs []tableland.ChainID,
-	allowList []string,
+	apiKey string,
 ) (*Router, error) {
 	// General router configuration.
 	router := newRouter()
@@ -27,9 +27,9 @@ func ConfiguredRouter(
 
 	cfg := middlewares.RateLimiterConfig{
 		Default: middlewares.RateLimiterRouteConfig{
-			MaxRPI:    maxRPI,
-			Interval:  rateLimInterval,
-			AllowList: allowList,
+			MaxRPI:   maxRPI,
+			Interval: rateLimInterval,
+			APIKey:   apiKey,
 		},
 	}
 	rateLim, err := middlewares.RateLimitController(cfg)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -19,6 +19,7 @@ func ConfiguredRouter(
 	maxRPI uint64,
 	rateLimInterval time.Duration,
 	supportedChainIDs []tableland.ChainID,
+	allowList []string,
 ) (*Router, error) {
 	// General router configuration.
 	router := newRouter()
@@ -26,8 +27,9 @@ func ConfiguredRouter(
 
 	cfg := middlewares.RateLimiterConfig{
 		Default: middlewares.RateLimiterRouteConfig{
-			MaxRPI:   maxRPI,
-			Interval: rateLimInterval,
+			MaxRPI:    maxRPI,
+			Interval:  rateLimInterval,
+			AllowList: allowList,
 		},
 	}
 	rateLim, err := middlewares.RateLimitController(cfg)

--- a/tests/fullstack/fullstack.go
+++ b/tests/fullstack/fullstack.go
@@ -131,7 +131,7 @@ func CreateFullStack(t *testing.T, deps Deps) FullStack {
 		require.NoError(t, err)
 	}
 
-	router, err := router.ConfiguredRouter(gatewayService, 10, time.Second, []tableland.ChainID{ChainID}, []string{})
+	router, err := router.ConfiguredRouter(gatewayService, 10, time.Second, []tableland.ChainID{ChainID}, "")
 	require.NoError(t, err)
 
 	server := httptest.NewServer(router.Handler())

--- a/tests/fullstack/fullstack.go
+++ b/tests/fullstack/fullstack.go
@@ -131,7 +131,7 @@ func CreateFullStack(t *testing.T, deps Deps) FullStack {
 		require.NoError(t, err)
 	}
 
-	router, err := router.ConfiguredRouter(gatewayService, 10, time.Second, []tableland.ChainID{ChainID})
+	router, err := router.ConfiguredRouter(gatewayService, 10, time.Second, []tableland.ChainID{ChainID}, []string{})
 	require.NoError(t, err)
 
 	server := httptest.NewServer(router.Handler())


### PR DESCRIPTION
# Summary

This PR adds a new config for the HTTP rate limiter: `ApiKey`. With that, authorized clients (clients that provide the same key) will not be rate limited. 

# Context

Our Studio application is being rate limited fairly easily. 

# Implementation overview

Adds a new config to be configured via env. Makes a change to the rate limiter middleware to ignore the authorized clients


