### PR TITLE
Avichalp/add goerli back

### DIFF
--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -4,7 +4,7 @@
         "Port": "8080",
         "RateLimInterval": "1s",
         "MaxRequestPerInterval": 10,
-        "ApiKey" : "${HTTP_RATE_LIMITER_API_KEY}",
+        "ApiKey": "${HTTP_RATE_LIMITER_API_KEY}",
         "TLSCert": "${VALIDATOR_TLS_CERT}",
         "TLSKey": "${VALIDATOR_TLS_KEY}"
     },

--- a/docker/deployed/testnet/api/config.json
+++ b/docker/deployed/testnet/api/config.json
@@ -4,7 +4,7 @@
         "Port": "8080",
         "RateLimInterval": "1s",
         "MaxRequestPerInterval": 10,
-        "ApiKey" : "${HTTP_RATE_LIMITER_API_KEY}", 
+        "ApiKey" : "${HTTP_RATE_LIMITER_API_KEY}",
         "TLSCert": "${VALIDATOR_TLS_CERT}",
         "TLSKey": "${VALIDATOR_TLS_KEY}"
     },
@@ -52,6 +52,25 @@
         "ChainStackCollectFrequency": "15m"
     },
     "Chains": [
+        {
+            "Name": "Ethereum Goerli",
+            "ChainID": 5,
+            "Registry": {
+                "EthEndpoint": "wss://eth-goerli.alchemyapi.io/v2/${VALIDATOR_ALCHEMY_ETHEREUM_GOERLI_API_KEY}",
+                "ContractAddress": "0xDA8EA22d092307874f30A1F277D1388dca0BA97a"
+            },
+            "EventFeed": {
+                "ChainAPIBackoff": "15s",
+                "NewBlockPollFreq": "10s",
+                "MinBlockDepth": 1,
+                "PersistEvents": true
+            },
+            "EventProcessor": {
+                "BlockFailedExecutionBackoff": "10s",
+                "DedupExecutedTxns": true
+            },
+            "HashCalculationStep": 150
+        },
         {
             "Name": "Ethereum Sepolia",
             "ChainID": 11155111,


### PR DESCRIPTION
Adding goerli back in the testnet. It turns out that some people are still using it in hackathons since it is still functional till the end of the year.

- [ ]  Are changes backward compatible with existing SDKs, or is there a plan to manage it correctly?
- [ ]  Are changes covered by existing tests, or were new tests included?
- [ ]  Are code changes optimized for future code readers, commenting on problematic areas to understand (if any)?
- [ ]  Future-self question: Did you avoid unjustified/unnecessary complexity to achieve the goal?
